### PR TITLE
Updates gosheets to version v0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -591,9 +591,9 @@
       }
     },
     "@tangoe/gosheets": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@tangoe/gosheets/-/gosheets-0.6.1.tgz",
-      "integrity": "sha512-mqoH378SUqpUol2p/v/y3DfZhHGnSV0f5FvHC1XQcwk8TILEOmhT/B0LN0kNfAC7qslDaOckOE3GYIDk2TFDrA=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@tangoe/gosheets/-/gosheets-0.7.1.tgz",
+      "integrity": "sha512-o4xngGBQOOAcgale7YN9fLv8YR0HdEo2DtcqXmf0Jxq03yZGevZackCM50zCs94aTCXAUQ6u3I7Iii/AECBBMA=="
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/platform-browser-dynamic": "~7.0.0",
     "@angular/router": "~7.0.0",
     "@tangoe/goponents": "file:dist/go-lib/tangoe-goponents-0.5.6.tgz",
-    "@tangoe/gosheets": "^0.6.1",
+    "@tangoe/gosheets": "^0.7.1",
     "core-js": "^2.5.4",
     "ngx-toastr": "^9.1.2",
     "npm": "^6.9.0",


### PR DESCRIPTION
With this update to the gosheets module we will get access to
several new features. v0.7.1 includes styles that will help us
streamline our buttons, icons, and form inputs.

This upgrade also gives us access to several more sass variables
and mixins.

This upgrade shouldn't have any impact on the current goponents
code. However, it will allow us to start changing some things around
in subsequent PRs.