### PR TITLE
Fixes the way data is exposed to the go-toast component

### DIFF
--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -1,7 +1,7 @@
 <div class="go-toast">
-  <div class="go-toast-strip" [ngClass]="statusClasses()"></div>
+  <div class="go-toast-strip" [ngClass]="statusClass"></div>
   <div class="go-toast-status">
-    <go-icon class="go-toast-status__icon" [ngClass]="statusClasses()" icon="{{ goIconType() }}"></go-icon>
+    <go-icon class="go-toast-status__icon" [ngClass]="statusClass" [icon]="icon"></go-icon>
   </div>
   <div class="go-toast-content"  [ngClass]="{ 'go-toast-content--no-title': !header }">
     <h5 class="go-toast-content__title" *ngIf="header">{{ header }}</h5>

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
@@ -5,7 +5,9 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
   templateUrl: './go-toast.component.html',
   styleUrls: ['./go-toast.component.scss']
 })
-export class GoToastComponent {
+export class GoToastComponent implements OnInit {
+  statusClass: string = 'go-toast-status--neutral';
+  icon: string = 'notifications_none';
 
   @Input() dismissable: boolean = false;
   @Input() header: string;
@@ -14,17 +16,29 @@ export class GoToastComponent {
 
   @Output() handleDismiss = new EventEmitter();
 
+  ngOnInit(): void {
+    this.statusClass = this.getStatus();
+    this.icon = this.getIcon();
+  }
+
+  public dismiss(): void {
+    this.handleDismiss.emit();
+  }
+
   //#region Private Methods
 
-  private statusClasses() : object {
-    return {
-      'go-toast-status--positive': this.type === 'positive',
-      'go-toast-status--neutral': this.type === 'neutral' || !this.type,
-      'go-toast-status--negative': this.type === 'negative'
+  private getStatus(): string {
+    switch (this.type) {
+      case 'positive':
+        return 'go-toast-status--positive';
+      case 'negative':
+        return 'go-toast-status--negative';
+      default:
+        return 'go-toast-status--neutral';
     }
   }
 
-  private goIconType() : string {
+  private getIcon(): string {
     switch (this.type) {
       case 'positive':
         return 'done';
@@ -33,10 +47,6 @@ export class GoToastComponent {
       default:
         return 'notifications_none'
     }
-  }
-
-  private dismiss() : void {
-    this.handleDismiss.emit();
   }
 
   //#endregion

--- a/projects/go-tester/src/app/app.component.ts
+++ b/projects/go-tester/src/app/app.component.ts
@@ -42,6 +42,8 @@ export class AppComponent implements OnInit {
 
     setTimeout(() => {
       this.goToasterService.toastInfo({ message: 'Check this out'});
+      this.goToasterService.toastSuccess({message: 'Check this out' });
+      this.goToasterService.toastError({ message: 'Check this out' });
     }, 1500);
   }
 


### PR DESCRIPTION
There was an issue we were running into when attempting to compile
goponents due to the toast component template not having access
to the functions that are private inside the component.ts file.

This keeps those private, but changes the way we expose those to
the template using static variables. This will fix this issue and
is probably a little bit more performant.