### PR TITLE
Total results calculated to NaN

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table-config.model.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table-config.model.ts
@@ -9,7 +9,7 @@ export class GoTableConfig {
   sortConfig?: GoTableSortConfig;
   sortable: boolean = true;
   tableData: any[];
-  totalCount?: number;
+  totalCount: number = null;
 
   constructor(fields?: {
     dataMode?: GoTableDataSource,


### PR DESCRIPTION
This removes the 'optional' flag on `totalCount` which apparently defaults to `undefined` and sets it to default to `null`.