### PR TITLE
Fix loadingData set incorrectly when table not sortable

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -76,8 +76,9 @@ export class GoTableComponent implements OnInit, OnChanges {
   toggleSort(columnField: string) : void {
     const { sortConfig, sortable, tableData } = this.localTableConfig;
 
-    this.loadingData = true;
     if (tableData && sortable) {
+      this.loadingData = true;
+
       if (sortConfig && sortConfig.column === columnField) {
         this.localTableConfig.sortConfig.direction = this.toggleSortDir(sortConfig.direction);
       } else {


### PR DESCRIPTION
If `sortable == false` on `GoTableConfig`, when column heading clicked to sort `loadingData` was set to `true` before we check if the table is sortable. This results in a persisted loading state with no way to reset it.