### PR TITLE
[Feature] Add Ability To Use Dark Theme For Buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,9 +1014,9 @@
       }
     },
     "@tangoe/gosheets": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@tangoe/gosheets/-/gosheets-0.7.2.tgz",
-      "integrity": "sha512-DBPrJmWi0F2XehE2AytZrSE7MqU47Gax3nvXSWGtzKNrS57+HYZoA6lJcS0SlhfV6rub1Afa03gUhBYx1OGP6Q=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@tangoe/gosheets/-/gosheets-0.8.1.tgz",
+      "integrity": "sha512-Z5sLdTqmgDmORP4bwOp5tveaQJLe4c9jizVnUJaoZplb4a+4V9alftHJWWGbB50Nrq0T15CsFFPidUAVZ6nLNQ=="
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/platform-browser": "~7.2.15",
     "@angular/platform-browser-dynamic": "~7.2.15",
     "@angular/router": "~7.2.15",
-    "@tangoe/gosheets": "^0.7.2",
+    "@tangoe/gosheets": "^0.8.1",
     "core-js": "^2.5.4",
     "ngx-toastr": "^9.1.2",
     "npm": "^6.9.0",

--- a/projects/go-lib/package.json
+++ b/projects/go-lib/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@angular/common": "^7.0.0",
     "@angular/core": "^7.0.0",
-    "@tangoe/gosheets": "^0.7.2",
+    "@tangoe/gosheets": "^0.8.1",
     "ngx-toastr": "^9.1.2"
   }
 }

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -10,6 +10,7 @@ export class GoButtonComponent {
   @Input() buttonType: string = 'button';
   @Input() buttonVariant: string;
   @Input() useLoader: boolean;
+  @Input() useDarkTheme: boolean;
 
   @Output() handleClick = new EventEmitter<boolean>();
 
@@ -21,7 +22,7 @@ export class GoButtonComponent {
     this.isProcessing = this.useLoader;
     this.handleClick.emit(this.isProcessing);
   }
-  
+
   public reset(): void {
     this.isProcessing = false;
   }
@@ -35,6 +36,7 @@ export class GoButtonComponent {
     ].includes(this.buttonVariant);
 
     return {
+      'go-button--dark': this.useDarkTheme,
       'go-button--loading': this.isProcessing,
       'go-button--negative': isNegative,
       'go-button--neutral': (this.buttonVariant === 'neutral'),

--- a/projects/go-tester/src/app/app.component.html
+++ b/projects/go-tester/src/app/app.component.html
@@ -41,6 +41,14 @@
   Hey
 </go-button>
 
+<go-button
+  [buttonIcon]="'home'"
+  buttonVariant="positive"
+  [useDarkTheme]="true"
+>
+  Dark
+</go-button>
+
 <br/>
 <br/>
 


### PR DESCRIPTION
This PR updates us to the latest version of gosheets and adds the functionality for using dark themed buttons within the go-button component through a binding called `useDarkTheme`.