### PR TITLE
Adds gosheets as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,9 +1014,9 @@
       }
     },
     "@tangoe/gosheets": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@tangoe/gosheets/-/gosheets-1.0.0-beta.1.tgz",
-      "integrity": "sha512-CbqsL/ha+APS1MfFe2+WkBC24hOMWmGJfGo4Fy1iGAqZLKI8vGGtF3m9jziWmBJbzO93itg0QWlh3y5HV8gIbQ=="
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@tangoe/gosheets/-/gosheets-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3IqbERP4XV7zyCQPq9hYJ0FylQ9hPcr4rzTk/vWXLN/blPWDufRvWB1OuCnd50pVH9KCtHjIMfJXa90kcz8gaA=="
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/platform-browser": "~7.2.15",
     "@angular/platform-browser-dynamic": "~7.2.15",
     "@angular/router": "~7.2.15",
-    "@tangoe/gosheets": "^1.0.0-beta.1",
+    "@tangoe/gosheets": "^1.0.0-beta.2",
     "core-js": "^2.5.4",
     "ngx-toastr": "^9.1.2",
     "npm": "^6.9.0",

--- a/projects/go-lib/package.json
+++ b/projects/go-lib/package.json
@@ -8,10 +8,12 @@
   "author": "Tangoe GoMobile",
   "description": "A library of UI components for Angular v7+.",
   "license": "MIT",
+  "peerDependencies": {
+    "@tangoe/gosheets": "^1.0.0-beta.2"
+  },
   "devDependencies": {
     "@angular/common": "^7.0.0",
     "@angular/core": "^7.0.0",
-    "@tangoe/gosheets": "^1.0.0-beta.1",
     "ngx-toastr": "^9.1.2"
   }
 }


### PR DESCRIPTION
The goponents module requires gosheets to work properly. Adding it
to the list of peerDepenencies will make it so a warning pops up
when you try to install one without the other.