### PR TITLE
[Feature] Side Navigation

### DIFF
--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.html
@@ -1,0 +1,32 @@
+<div class="go-nav-group"
+     [ngClass]="{ 'go-nav-group--expanded': navItem.expanded }"
+     *ngIf="navItem.subRoutes && navItem.subRoutes.length > 0">
+  <div class="go-nav-group__dropdown" (click)="expand(navItem)">
+    <div class="go-nav-group__link">
+      <go-icon [icon]="navItem.routeIcon"
+               iconClass="go-nav-group__icon"
+               *ngIf="navItem.routeIcon">
+      </go-icon>
+      <span class="go-nav-group__title" *ngIf="navService.navOpen">
+        {{ navItem.routeTitle }}
+      </span>
+    </div>
+    <go-icon iconClass="go-nav-group__expand-icon"
+             icon="expand_more"
+             *ngIf="navService.navOpen"
+             [ngClass]="{ 'go-nav-group__expand-icon--expanded': navItem.expanded }">
+    </go-icon>
+  </div>
+  <div *ngIf="navItem.expanded">
+    <div *ngFor="let item of navItem.subRoutes">
+      <go-nav-group *ngIf="item.subRoutes; else subRoutesElse"
+                    class="go-nav-group__inner-group"
+                    [navItem]="item">
+      </go-nav-group>
+      <ng-template #subRoutesElse>
+        <go-nav-item *ngIf="!item.subRoutes" [navItem]="item"></go-nav-item>
+      </ng-template>
+    </div>
+  </div>
+</div>
+<go-nav-item *ngIf="!navItem.subRoutes" [navItem]="navItem"></go-nav-item>

--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.scss
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.scss
@@ -1,0 +1,60 @@
+@import '~@tangoe/gosheets/base/variables';
+@import '~@tangoe/gosheets/base/mixins';
+@import '../../../../styles/variables';
+
+.go-nav-group__dropdown {
+  align-items: center;
+  display: flex;
+  padding-right: .5rem;
+  user-select: none;
+  @include transition(all);
+
+  &:hover {
+    background: $theme-dark-bg-hover;
+  }
+}
+
+.go-nav-group__link {
+  display: flex;
+  flex-grow: 1;
+}
+
+.go-nav-group__title {
+  font-weight: $weight-light;
+  letter-spacing: $side-nav-letter-spacing;
+  padding: $outer-side-nav-padding;
+}
+
+.go-nav-group__icon {
+  font-size: 1.2rem;
+  padding: 1rem;
+}
+
+.go-nav-group__expand-icon {
+  border-radius: 50%;
+  color: $theme-dark-color;
+  cursor: pointer;
+  font-size: 1.5rem;
+  height: 2.5rem;
+  padding: 0.5rem;
+  width: 2.5rem;
+
+  &:hover {
+    background: $theme-dark-bg;
+  }
+}
+
+.go-nav-group__expand-icon--expanded {
+  transform: rotate(180deg);
+}
+
+.go-nav-group__inner-group {
+  .go-nav-group__title {
+    font-size: $inner-side-nav-font-size;
+    padding: $inner-side-nav-padding;
+  }
+}
+
+.go-nav-group--expanded {
+  background: $theme-dark-bg-active;
+}

--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input, ViewEncapsulation, Output, EventEmitter } from '@angular/core';
+import { NavGroup } from '../nav-group.model';
+import { NavItem } from '../nav-item.model';
+import { GoSideNavService } from '../go-side-nav/go-side-nav.service';
+
+@Component({
+  selector: 'go-nav-group',
+  templateUrl: './go-nav-group.component.html',
+  styleUrls: ['./go-nav-group.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class GoNavGroupComponent {
+  @Input() navItem: NavGroup | NavItem;
+  @Input() class: string;
+  @Output() closeNavs = new EventEmitter<NavGroup>();
+
+  constructor (public navService: GoSideNavService) { }
+
+  expand(navGroup: NavGroup): void {
+    navGroup.expanded = !navGroup.expanded;
+
+    if (!this.navService.navOpen) {
+      this.navService.toggleNav();
+    }
+
+    if (navGroup.expanded) {
+      this.closeNavs.emit(navGroup);
+    }
+  }
+}

--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.html
@@ -1,0 +1,17 @@
+<div class="go-nav-item"
+     [title]="description">
+  <a class="go-nav-item__link"
+     [routerLinkActive]="['go-nav-item__link--active']"
+     [routerLink]="[navItem.route]"
+     [routerLinkActiveOptions]="{exact:true}">
+    <go-icon [icon]="navItem.routeIcon"
+             iconClass="go-nav-group__icon"
+             *ngIf="navItem.routeIcon">
+    </go-icon>
+    <span [ngClass]="{ 'go-nav-item__title--with-icon': navItem.routeIcon }"
+          class="go-nav-item__title"
+          *ngIf="navService.navOpen">
+      {{navItem.routeTitle}}
+    </span>
+  </a>
+</div>

--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.scss
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.scss
@@ -1,0 +1,65 @@
+@import '~@tangoe/gosheets/base/variables';
+@import '~@tangoe/gosheets/base/mixins';
+@import '../../../../styles/variables';
+
+.go-nav-item {
+  align-items: center;
+  display: flex;
+  padding-right: .5rem;
+  @include transition(all);
+
+  &:hover {
+    background: $theme-dark-bg-hover;
+  }
+}
+
+.go-nav-item__link::before {
+  background: $base-primary;
+  border-radius: 0 $global-radius $global-radius 0;
+  content: " ";
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 4px;
+  @include transition(all);
+}
+
+.go-nav-item__link--active {
+  .go-nav-item__title {
+    font-weight: $weight-regular;
+  }
+}
+
+.go-nav-item__link--active::before {
+  opacity: 1;
+}
+
+.go-nav-item__link,
+.go-nav-item__link:visited,
+.go-nav-item__link:focus,
+.go-nav-item__link:active {
+  color: $theme-dark-color;
+}
+
+.go-nav-item__link {
+  align-items: center;
+  border: none;
+  display: flex;
+  flex-grow: 1;
+  position: relative;
+  text-decoration: none;
+}
+
+.go-nav-item__title {
+  font-size: $inner-side-nav-font-size;
+  font-weight: $weight-light;
+  letter-spacing: $side-nav-letter-spacing;
+  padding: $inner-side-nav-padding;
+}
+
+.go-nav-item__title--with-icon {
+  font-size: 1rem;
+  padding: $outer-side-nav-padding;
+}

--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { NavItem } from '../nav-item.model';
+import { GoSideNavService } from '../go-side-nav/go-side-nav.service';
+
+@Component({
+  selector: 'go-nav-item',
+  templateUrl: './go-nav-item.component.html',
+  styleUrls: ['./go-nav-item.component.scss']
+})
+export class GoNavItemComponent {
+  @Input() navItem: NavItem;
+
+  constructor (public navService: GoSideNavService) { }
+}

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav.module.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { GoIconModule } from '../go-icon/go-icon.module';
+
+import { GoSideNavComponent } from './go-side-nav/go-side-nav.component';
+import { GoNavGroupComponent } from './go-nav-group/go-nav-group.component';
+import { GoNavItemComponent } from './go-nav-item/go-nav-item.component';
+
+@NgModule({
+  declarations: [
+    GoSideNavComponent,
+    GoNavGroupComponent,
+    GoNavItemComponent
+  ],
+  imports: [
+    CommonModule,
+    GoIconModule,
+    RouterModule
+  ],
+  exports: [
+    GoSideNavComponent,
+    GoNavGroupComponent,
+    GoNavItemComponent
+  ]
+})
+
+export class GoSideNavModule { }

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
@@ -1,0 +1,7 @@
+<div class="go-side-nav"
+     [ngClass]="{ 'go-side-nav--show-mobile' : navService.navOpen, 'go-side-nav--collapsed' : !navService.navOpen }">
+  <go-nav-group *ngFor="let item of menuItems"
+                [navItem]="item"
+                (closeNavs)="closeNavs($event)">
+  </go-nav-group>
+</div>

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.scss
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.scss
@@ -1,0 +1,27 @@
+@import '~@tangoe/gosheets/base/_variables';
+@import '../../../../styles/variables';
+
+.go-side-nav {
+  background: $theme-dark-bg;
+  color: $theme-dark-color;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  height: 100%;
+  overflow-y: auto;
+  padding: 2rem 0;
+  width: $side-nav-width;
+
+  @media(max-width: $breakpoint-mobile) {
+    display: none;
+
+    &.go-side-nav--show-mobile {
+      display: flex;
+      width: 100vw;
+    }
+  }
+
+  &.go-side-nav--collapsed {
+    width: $side-nav-width--collapsed;
+  }
+}

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
@@ -1,0 +1,77 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs/operators';
+import { NavGroup } from '../nav-group.model';
+import { NavItem } from '../nav-item.model';
+import { GoSideNavService } from './go-side-nav.service';
+
+@Component({
+  selector: 'go-side-nav',
+  templateUrl: './go-side-nav.component.html',
+  styleUrls: ['./go-side-nav.component.scss']
+})
+export class GoSideNavComponent implements OnInit {
+  @Input() menuItems: Array<NavGroup | NavItem>;
+
+  constructor (private router: Router, public navService: GoSideNavService) { }
+
+  ngOnInit(): void {
+    this.router.events
+      .pipe(
+        filter(event => event instanceof NavigationEnd)
+      ).subscribe((event: NavigationEnd) => {
+        this.menuItems.forEach(item => {
+          (item as NavGroup).expanded = this.setExpanded(item, event.url);
+        });
+    });
+  }
+
+  closeNavs(navGroup: NavGroup): void {
+    this.menuItems.forEach(group => {
+      const g = group as NavGroup;
+      g.expanded = this.openAccordion(g, navGroup);
+    });
+  }
+
+  //#region Private Methods
+
+  private setExpanded(item: NavGroup | NavItem, url: string): boolean {
+    if ((item as NavGroup).subRoutes) {
+      return this.navGroupExpansion(item as NavGroup, url);
+    } else {
+      return url.includes((item as NavItem).route);
+    }
+  }
+
+  private navGroupExpansion(group: NavGroup, url: string): boolean {
+    group.expanded = group.subRoutes.some(subRoute => {
+      return this.setExpanded(subRoute, url);
+    });
+    return group.expanded;
+  }
+
+  /**
+   * @description this goes through and opens the accordion of the group that was clicked on and
+   * closes the other accordions that were previously open if they are not above the group that was
+   * clicked on. It uses recursion to go through nested groups to make sure that if a child group
+   * is open the parents of the child is also open.
+   * @param group this is the group we are trying to decide if it should be open.
+   * @param item this is the group that we are searching for that was clicked on and needs opened.
+   */
+
+  private openAccordion(group: NavGroup, item: NavGroup): boolean {
+    if (group.subRoutes) {
+      if (group.routeTitle !== item.routeTitle) {
+        group.expanded = group.subRoutes.some(subRoute => {
+          return this.openAccordion((subRoute as NavGroup), item);
+        });
+      } else {
+        group.expanded = true;
+      }
+
+      return group.expanded;
+    }
+    return false;
+  }
+  //#endregion
+}

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.service.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Observable, of as observableOf, BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+
+export class GoSideNavService {
+  public navOpen = true;
+
+  constructor() { }
+
+  toggleNav() {
+    this.navOpen = !this.navOpen;
+  }
+}

--- a/projects/go-lib/src/lib/components/go-side-nav/nav-group.model.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/nav-group.model.ts
@@ -1,0 +1,8 @@
+import { NavItem } from './nav-item.model';
+
+export interface NavGroup {
+  expanded?: boolean;
+  routeIcon?: string;
+  routeTitle: string;
+  subRoutes: Array<NavGroup | NavItem>;
+}

--- a/projects/go-lib/src/lib/components/go-side-nav/nav-item.model.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/nav-item.model.ts
@@ -1,0 +1,6 @@
+export interface NavItem {
+  description?: string;
+  route: string;
+  routeIcon?: string;
+  routeTitle: string;
+}

--- a/projects/go-lib/src/lib/go-shared.module.ts
+++ b/projects/go-lib/src/lib/go-shared.module.ts
@@ -5,6 +5,7 @@ import { GoCardModule } from './components/go-card/go-card.module';
 import { GoIconModule } from './components/go-icon/go-icon.module';
 import { GoLoaderModule } from './components/go-loader/go-loader.module';
 import { GoModalModule } from './components/go-modal/go-modal.module';
+import { GoSideNavModule } from './components/go-side-nav/go-side-nav.module';
 import { GoTableModule } from './components/go-table/go-table.module';
 import { GoToastModule } from './components/go-toast/go-toast.module';
 import { GoToasterModule } from './components/go-toaster/go-toaster.module';
@@ -17,6 +18,7 @@ import { GoToasterModule } from './components/go-toaster/go-toaster.module';
     GoIconModule,
     GoLoaderModule,
     GoModalModule,
+    GoSideNavModule,
     GoTableModule,
     GoToastModule,
     GoToasterModule
@@ -28,6 +30,7 @@ import { GoToasterModule } from './components/go-toaster/go-toaster.module';
     GoIconModule,
     GoLoaderModule,
     GoModalModule,
+    GoSideNavModule,
     GoTableModule,
     GoToastModule,
     GoToasterModule

--- a/projects/go-lib/src/public_api.ts
+++ b/projects/go-lib/src/public_api.ts
@@ -36,6 +36,13 @@ export * from './lib/components/go-off-canvas/go-off-canvas.component';
 export * from './lib/components/go-off-canvas/go-off-canvas.module';
 export * from './lib/components/go-off-canvas/go-off-canvas.service';
 
+// Side Nav
+export * from './lib/components/go-side-nav/go-side-nav.module';
+export * from './lib/components/go-side-nav/nav-group.model';
+export * from './lib/components/go-side-nav/nav-item.model';
+export * from './lib/components/go-side-nav/go-side-nav/go-side-nav.component';
+export * from './lib/components/go-side-nav/go-side-nav/go-side-nav.service';
+
 // Table
 export * from './lib/components/go-table/go-table.component';
 export * from './lib/components/go-table/go-table.module';

--- a/projects/go-lib/src/styles/_variables.scss
+++ b/projects/go-lib/src/styles/_variables.scss
@@ -8,3 +8,13 @@ $brand-color-hover: darken($base-primary, 10%);
 $brand-color-dark: darken($base-primary, 15%);
 $brand-color-darker: darken($base-primary, 20%);
 $brand-color-gradient: linear-gradient(to right, $base-primary, $brand-color-hover);
+
+// Structure
+$side-nav-width: 15.5rem;
+$side-nav-width--collapsed: 3.2rem;
+
+// SideNav
+$inner-side-nav-font-size: 0.875rem;
+$inner-side-nav-padding: $column-gutter--half $column-gutter--three-quarters $column-gutter--half 3.2rem;
+$outer-side-nav-padding: 1rem 1rem 1rem 0;
+$side-nav-letter-spacing: .02rem;

--- a/projects/go-tester/src/app/app.component.html
+++ b/projects/go-tester/src/app/app.component.html
@@ -1,85 +1,97 @@
-<div class="go-container" style="margin: 0;">
+<div class="main">
+  <header>
+    <div class="header__logo">
+      <go-icon icon="menu" iconClass="go-nav-group__icon" (click)="toggleSideMenu()"></go-icon>
+    </div>
+  </header>
+  <div class="main__content">
+    <go-side-nav [menuItems]="menuItems">
+    </go-side-nav>
+    <div class="main__content--container">
+      <div class="go-container" style="margin: 0;">
 
-  <div class="go-column go-column--100">
-    <h1 class="go-header-2">
-      Welcome to {{ title }}!
-    </h1>
-  </div>
+        <div class="go-column go-column--100">
+          <h1 class="go-header-2">
+            Welcome to {{ title }}!
+          </h1>
+        </div>
 
-  <div class="go-column go-column--100">
-    <h4>Loader</h4>
-    <go-button (handleClick)="stopLoaderAnimation()">
-      Toggle Animation
-    </go-button>
-    <br>
-    <br>
-    <div class="go-container">
-      <div class="go-column go-column--100">
-        <go-loader #loader loaderSize="small"></go-loader>
-        <go-loader></go-loader>
-        <go-loader loaderSize="large"></go-loader>
+        <div class="go-column go-column--100">
+          <h4>Loader</h4>
+          <go-button (handleClick)="stopLoaderAnimation()">
+            Toggle Animation
+          </go-button>
+          <br>
+          <br>
+          <div class="go-container">
+            <div class="go-column go-column--100">
+              <go-loader #loader loaderSize="small"></go-loader>
+              <go-loader></go-loader>
+              <go-loader loaderSize="large"></go-loader>
+            </div>
+          </div>
+        </div>
+        
+        <div class="go-column go-column--100">
+          <h4>Buttons</h4>
+          <go-button buttonIcon="home">
+            Hey
+          </go-button>
+          <go-button buttonIcon="add_shopping_cart" buttonVariant="positive" (handleClick)="clickHey()" [useLoader]="true" #heyButton>
+            Hey
+          </go-button>
+          <go-button buttonIcon="fingerprint" buttonVariant="negative">
+            Hey
+          </go-button>
+          <go-button buttonIcon="fingerprint" buttonVariant="negative" buttonDisabled="true">
+            Nope
+          </go-button>
+          <go-button buttonIcon="plus_one" buttonVariant="neutral">
+            Hey
+          </go-button>
+          <go-button [buttonIcon]="'home'" buttonVariant="positive" [useDarkTheme]="true">
+            Dark
+          </go-button>
+        </div>
+
+        <div class="go-column go-column--100">
+          <h4>Off Canvas</h4>
+          <go-button buttonIcon="home" (handleClick)="openThing()">
+            Click me to open
+          </go-button>
+        </div>
+
+        <div class="go-column go-column--100">
+          <h4>Toasts</h4>
+          <go-toast type="neutral"
+                    header="Announcement!"
+                    [dismissable]="true">
+          </go-toast>
+        </div>
+
+        <div class="go-column go-column--100">
+          <h4>Table</h4>
+          <go-table [loadingData]="tableLoading"
+                    [tableConfig]="tableConfig"
+                    (tableChange)="handleTableChange($event)"
+                    tableTitle="People Data"
+                    *ngIf="tableConfig">
+            <go-table-column field="id" title="ID"></go-table-column>
+            <go-table-column field="name.first" title="First Name"></go-table-column>
+            <go-table-column field="name.last" title="Last Name"></go-table-column>
+            <go-table-column field="email" title="Email"></go-table-column>
+            <go-table-column field="gender" title="Gender"></go-table-column>
+            <go-table-column field="ip_address" title="IP Address"></go-table-column>
+            <go-table-column>
+              <ng-template #goTableCell let-item>
+                <go-icon icon="delete"></go-icon>
+              </ng-template>
+            </go-table-column>
+          </go-table>
+        </div>
       </div>
     </div>
   </div>
-  
-  <div class="go-column go-column--100">
-    <h4>Buttons</h4>
-    <go-button buttonIcon="home">
-      Hey
-    </go-button>
-    <go-button buttonIcon="add_shopping_cart" buttonVariant="positive" (handleClick)="clickHey()" [useLoader]="true" #heyButton>
-      Hey
-    </go-button>
-    <go-button buttonIcon="fingerprint" buttonVariant="negative">
-      Hey
-    </go-button>
-    <go-button buttonIcon="fingerprint" buttonVariant="negative" buttonDisabled="true">
-      Nope
-    </go-button>
-    <go-button buttonIcon="plus_one" buttonVariant="neutral">
-      Hey
-    </go-button>
-    <go-button [buttonIcon]="'home'" buttonVariant="positive" [useDarkTheme]="true">
-      Dark
-    </go-button>
-  </div>
-
-  <div class="go-column go-column--100">
-    <h4>Off Canvas</h4>
-    <go-button buttonIcon="home" (handleClick)="openThing()">
-      Click me to open
-    </go-button>
-  </div>
-
-  <div class="go-column go-column--100">
-    <h4>Toasts</h4>
-    <go-toast type="neutral"
-              header="Announcement!"
-              [dismissable]="true">
-    </go-toast>
-  </div>
-
-  <div class="go-column go-column--100">
-    <h4>Table</h4>
-    <go-table [loadingData]="tableLoading"
-              [tableConfig]="tableConfig"
-              (tableChange)="handleTableChange($event)"
-              tableTitle="People Data"
-              *ngIf="tableConfig">
-      <go-table-column field="id" title="ID"></go-table-column>
-      <go-table-column field="name.first" title="First Name"></go-table-column>
-      <go-table-column field="name.last" title="Last Name"></go-table-column>
-      <go-table-column field="email" title="Email"></go-table-column>
-      <go-table-column field="gender" title="Gender"></go-table-column>
-      <go-table-column field="ip_address" title="IP Address"></go-table-column>
-      <go-table-column>
-        <ng-template #goTableCell let-item>
-          <go-icon icon="delete"></go-icon>
-        </ng-template>
-      </go-table-column>
-    </go-table>
-  </div>
 </div>
-
 <go-toaster></go-toaster>
 <go-off-canvas></go-off-canvas>

--- a/projects/go-tester/src/app/app.component.scss
+++ b/projects/go-tester/src/app/app.component.scss
@@ -1,0 +1,24 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  max-height: 100vh;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.main__content {
+  left: 0;
+  display: flex;
+  flex-grow: 1;
+  height: 100%;
+  overflow: hidden;
+}
+
+.main__content--container {
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 3rem;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+}

--- a/projects/go-tester/src/app/app.component.ts
+++ b/projects/go-tester/src/app/app.component.ts
@@ -8,7 +8,10 @@ import {
   GoButtonComponent,
   GoIconComponent,
   GoLoaderComponent,
-  GoToasterService
+  GoSideNavService,
+  GoToasterService,
+  NavGroup,
+  NavItem
 } from '../../../go-lib/src/public_api';
 
 @Component({
@@ -26,10 +29,34 @@ export class AppComponent implements OnInit {
   tableConfig: GoTableConfig;
   tableLoading: boolean = true;
 
+  menuItems: Array<NavGroup | NavItem> = [
+    { route: 'getting-started', routeIcon: 'power_settings_new', routeTitle: 'Getting Started' },
+    {routeIcon: 'gavel', routeTitle: 'Standards', subRoutes: [
+      { route: 'standards/colors', routeTitle: 'Colors' },
+      { route: 'standards/forms', routeTitle: 'Forms' },
+      { route: 'standards/grid', routeTitle: 'Grid System' },
+      { routeTitle: 'Nested Typography', subRoutes: [
+        { route: 'whatever', routeTitle: 'This is nested'}
+      ]}
+    ]},
+    {routeIcon: 'widgets', routeTitle: 'Components', subRoutes: [
+      { route: 'ui-kit/accordion', routeTitle: 'Accordion' },
+      { route: 'ui-kit/accordion-panel', routeTitle: 'Accordion Panel' },
+      { route: 'ui-kit/button', routeTitle: 'Button' },
+      { route: 'ui-kit/card', routeTitle: 'Card' },
+      { route: 'ui-kit/icon', routeTitle: 'Icon' },
+      { route: 'ui-kit/modal', routeTitle: 'Modal' },
+      { route: 'ui-kit/off-canvas', routeTitle: 'Off Canvas' },
+      { route: 'ui-kit/table', routeTitle: 'Table'},
+      { route: 'ui-kit/toast', routeTitle: 'Toast' }
+    ]}
+  ];
+
   constructor(
     private appService: AppService,
     private goToasterService: GoToasterService,
-    private goOffCanvasService: GoOffCanvasService
+    private goOffCanvasService: GoOffCanvasService,
+    private goSideNavService: GoSideNavService
   ) { }
 
   ngOnInit() {
@@ -80,5 +107,9 @@ export class AppComponent implements OnInit {
         icon: 'alarm'
       }
     });
+  }
+
+  toggleSideMenu(): void {
+    this.goSideNavService.toggleNav();
   }
 }

--- a/projects/go-tester/src/app/app.module.ts
+++ b/projects/go-tester/src/app/app.module.ts
@@ -2,6 +2,8 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
+import { AppRoutingModule } from './app.router';
+import { DummyComponent } from './dummy.component'
 
 import {
   GoButtonComponent,
@@ -10,6 +12,7 @@ import {
   GoIconModule,
   GoLoaderModule,
   GoOffCanvasModule,
+  GoSideNavModule,
   GoTableModule,
   GoToastModule,
   GoToasterModule
@@ -21,7 +24,8 @@ import { AppService } from './app.service';
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
+    DummyComponent
   ],
   imports: [
     BrowserModule,
@@ -31,9 +35,11 @@ import { AppService } from './app.service';
     GoIconModule,
     GoLoaderModule,
     GoOffCanvasModule,
+    GoSideNavModule,
     GoTableModule,
     GoToastModule,
-    GoToasterModule
+    GoToasterModule,
+    AppRoutingModule
   ],
   providers: [
     AppService

--- a/projects/go-tester/src/app/app.router.ts
+++ b/projects/go-tester/src/app/app.router.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { DummyComponent } from './dummy.component';
+
+const routes: Routes = [
+  { path: '**', component: DummyComponent}
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
+export class AppRoutingModule { }

--- a/projects/go-tester/src/app/dummy.component.ts
+++ b/projects/go-tester/src/app/dummy.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'route-dummy',
+  template: ''
+})
+
+export class DummyComponent {
+}

--- a/projects/go-tester/src/styles.scss
+++ b/projects/go-tester/src/styles.scss
@@ -6,4 +6,5 @@
 body {
   background: $theme-light-app-bg;
   font-family: 'Roboto';
+  margin: 0px;
 }


### PR DESCRIPTION
This implements a side nav that can be dropped into a layout.

To use it you would drop the side navigation into the app template as the first thing in the content.

```
<go-side-nav [menuItems]="menuItems"></go-side-nav>
```

It takes one parameter which is menuItems which takes a list of things that goes into the side nav. These can either be a group of items or an item. A group would have an array of subRoutes while a normal item would have a route and a routeTitle. The route is the url that the button goes to while the routeTitle is what is displayed on the button. Each item or group on the top level of the navigation needs to have a routeIcon attached to it for the purposes of collapsing the navigation. If a group doesn't have any subroutes it will be hidden by default.

ex list of menuItems

```
[
  { route: 'getting-started', routeIcon: 'power_settings_new', routeTitle: 'Getting Started' },
  { routeIcon: 'gavel', routeTitle: 'Standards', subRoutes: [
    { route: 'standards/colors', routeTitle: 'Colors' },
  ]}
]
```