### PR TITLE
Add title attribute to go-icon-button

### DIFF
--- a/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.html
+++ b/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.html
@@ -2,6 +2,7 @@
   class="go-icon-button"
   (click)="clicked()"
   [disabled]="buttonDisabled"
+  [title]="buttonTitle"
   type="button"
 >
   <go-icon

--- a/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.ts
@@ -7,6 +7,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class GoIconButtonComponent {
   @Input() buttonDisabled: boolean;
   @Input() buttonIcon: string;
+  @Input() buttonTitle: string;
 
   @Output() handleClick = new EventEmitter();
 

--- a/projects/go-tester/src/app/app.component.html
+++ b/projects/go-tester/src/app/app.component.html
@@ -64,7 +64,7 @@
         </div>
         <div class="go-column go-column--100">
           <h4>Icon Button</h4>
-          <go-icon-button buttonIcon="home" (handleClick)="openThing()"></go-icon-button>
+          <go-icon-button buttonTitle="Home" buttonIcon="home" (handleClick)="openThing()"></go-icon-button>
         </div>
 
         <div class="go-column go-column--100">


### PR DESCRIPTION
Addresses [#83](https://github.com/mobi/goponents/issues/83)

Adds a `buttonTitle` binding to go-icon-button component which passes its value to the `title` attribute of the button element encapsulated within the go-icon-button, thus enabling tooltips.