### PR TITLE
Firefox Search Animation Errors

### DIFF
--- a/projects/go-lib/src/lib/animations/search.animation.ts
+++ b/projects/go-lib/src/lib/animations/search.animation.ts
@@ -21,6 +21,9 @@ export const searchLoaderAnim = trigger('searchLoaderAnim', [
     }))
   ]),
   transition(':leave', [
+    style({
+      padding: '2rem'
+    }),
     animate(timing + ' ' + easing, style({
       height: 0,
       opacity: 0,
@@ -44,7 +47,8 @@ export const searchResultsAnim = trigger('searchResultsAnim', [
   ]),
   transition(':leave', [
     style({
-      overflowY: 'hidden'
+      overflowY: 'hidden',
+      margin: '1rem 0 0.5rem 0'
     }),
     animate(timing + ' ' + easing, style({
       height: 0,


### PR DESCRIPTION
Fixes #81 

In firefox the loading spinner and no results content never go away after they appear. If they get triggered again, the content just gets duplicated. This is happening because of https://github.com/angular/angular/issues/20489. In order to fix it we can just add the base styles on the leave animation instead of relying on the browser to find them.