### PR TITLE
Updates linter rules to enforce type definitions everywhere

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,18 @@
         "named-imports-order": "case-insensitive",
         "module-source-path": "any"
       }
+    ],
+    "typedef": [
+      true,
+      "call-signature",
+      "arrow-call-signature",
+      "parameter",
+      "arrow-parameter",
+      "property-declaration",
+      "variable-declaration",
+      "member-variable-declaration",
+      "object-destructuring",
+      "array-destructuring"
     ]
   }
 }


### PR DESCRIPTION
This updates out linter rules to enforce type definitions on all of the things.

---------------------
![36rlfe](https://user-images.githubusercontent.com/1075489/62055119-fc018d80-b1e8-11e9-9eee-b804894dd9d7.jpg)
