### PR TITLE
Renames title to panelContent to avoid conflicts with native functionality

### DIFF
--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
@@ -4,7 +4,7 @@
    *ngIf="externalLink; else noLink">
   <span class="go-panel__title">
     <span *ngIf="icon" class="go-panel__icon material-icons">{{icon}}</span>
-    <span class="go-panel__title-text" [innerHtml]="title"></span>
+    <span class="go-panel__title-text" [innerHtml]="panelContent"></span>
   </span>
 </a>
 
@@ -14,7 +14,7 @@
           (click)="handleAction()">
     <span class="go-panel__title">
       <span *ngIf="icon" class="go-panel__icon material-icons">{{icon}}</span>
-      <span class="go-panel__title-text" [innerHtml]="title"></span>
+      <span class="go-panel__title-text" [innerHtml]="panelContent"></span>
     </span>
   </button>
 </ng-template>

--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.ts
@@ -8,10 +8,10 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 export class GoPanelComponent {
 
   @Input() danger: boolean;
-  @Input() header: boolean;
+  @Input() showHeader: boolean;
   @Input() icon: string;
   @Input() externalLink: string;
-  @Input() title: string;
+  @Input() panelContent: string;
 
   @Output() action: EventEmitter<void> = new EventEmitter<void>();
 
@@ -20,7 +20,7 @@ export class GoPanelComponent {
   panelClasses(): object {
     return {
       'go-panel--danger': this.danger,
-      'go-panel--header': this.header
+      'go-panel--header': this.showHeader
     }
   }
 

--- a/projects/go-tester/src/app/app.component.html
+++ b/projects/go-tester/src/app/app.component.html
@@ -14,20 +14,23 @@
           <go-icon-button buttonIcon="input"></go-icon-button>
         </ng-container>
         <ng-container go-action-sheet-content>
-          <go-panel header="true" title="Christoph<br><p>christoph.drechsler@tangoe.com</p>">
+          <go-panel
+            showHeader="true"
+            panelContent="Christoph<br><p>christoph.drechsler@tangoe.com</p>"
+          >
           </go-panel>
-          <go-panel title="Router Link" icon="folder" routerLink="/test-page-1">
+          <go-panel panelContent="Router Link" icon="folder" routerLink="/test-page-1">
           </go-panel>
-          <go-panel icon="open_in_new" title="External Link" externalLink="https://www.google.com">
+          <go-panel icon="open_in_new" panelContent="External Link" externalLink="https://www.google.com">
           </go-panel>
-          <go-panel title="Open Toast" icon="folder" (action)="openToast()">
+          <go-panel panelContent="Open Toast" icon="folder" (action)="openToast()">
           </go-panel>
           <go-accordion showIcons="true" [slim]="true" class="go-action-sheet__go-accordion">
             <go-accordion-panel title="Accordion" icon="home">
               Another test 
             </go-accordion-panel>
           </go-accordion>
-          <go-panel danger="true" title="Logout" icon="lock">
+          <go-panel danger="true" panelContent="Logout" icon="lock">
           </go-panel>
         </ng-container>
       </go-action-sheet>

--- a/projects/go-tester/src/app/components/test-page-2/test-page-2.component.html
+++ b/projects/go-tester/src/app/components/test-page-2/test-page-2.component.html
@@ -14,20 +14,20 @@
         </go-button>
       </ng-container>
       <ng-container go-action-sheet-content>
-        <go-panel header="true" title="Christoph<br><p>christoph.drechsler@tangoe.com</p>">
+        <go-panel showHeader="true" panelContent="Christoph<br><p>christoph.drechsler@tangoe.com</p>">
         </go-panel>
-        <go-panel title="Router Link" icon="folder" routerLink="/test-page-1">
+        <go-panel panelContent="Router Link" icon="folder" routerLink="/test-page-1">
         </go-panel>
-        <go-panel icon="open_in_new" title="External Link" externalLink="https://www.google.com">
+        <go-panel icon="open_in_new" panelContent="External Link" externalLink="https://www.google.com">
         </go-panel>
-        <go-panel title="Open Toast" icon="folder" (action)="openToast()">
+        <go-panel panelContent="Open Toast" icon="folder" (action)="openToast()">
         </go-panel>
         <go-accordion showIcons="true" [slim]="true" class="go-action-sheet__go-accordion">
           <go-accordion-panel title="Accordion" icon="home">
             Another test 
           </go-accordion-panel>
         </go-accordion>
-        <go-panel danger="true" title="Logout" icon="lock">
+        <go-panel danger="true" panelContent="Logout" icon="lock">
         </go-panel>
       </ng-container>
     </go-action-sheet>


### PR DESCRIPTION
We had an issue with the <go-panel> component where the title @input
was exposing things we didn't want it to because of its naming
collision with the native title attribute. Updating the name of said
attribute to panelContent fixes this issue.

#### Screenshot
<img width="304" alt="Screen Shot 2019-07-30 at 9 54 45 AM" src="https://user-images.githubusercontent.com/1075489/62135440-371ac400-b2b0-11e9-98f5-2c67d7dc75b8.png">
