### PR TITLE
Compilation Errors Fix

### DIFF
--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.html
@@ -1,9 +1,9 @@
 <div class="go-nav-group"
-     [ngClass]="{ 'go-nav-group--expanded': navItem.expanded }"
-     *ngIf="navItem.subRoutes && navItem.subRoutes.length > 0; else noSubRoutes">
+     [ngClass]="{ 'go-nav-group--expanded': group.expanded }"
+     *ngIf="group.subRoutes && group.subRoutes.length > 0; else noSubRoutes">
   <div class="go-nav-group__dropdown"
-       (click)="expand(navItem)"
-       [attr.title]="navItem.description">
+       (click)="expand(group)"
+       [attr.title]="group.description">
     <div class="go-nav-group__link">
       <go-icon [icon]="navItem.routeIcon"
                iconClass="go-nav-group__icon"
@@ -16,17 +16,17 @@
     <go-icon class="go-nav-group__expand-icon"
              icon="expand_more"
              *ngIf="navService.navOpen"
-             [ngClass]="{ 'go-nav-group__expand-icon--expanded': navItem.expanded }">
+             [ngClass]="{ 'go-nav-group__expand-icon--expanded': group.expanded }">
     </go-icon>
   </div>
-  <div *ngIf="navItem.expanded">
-    <div *ngFor="let item of navItem.subRoutes">
+  <div *ngIf="group.expanded">
+    <div *ngFor="let item of group.subRoutes">
       <go-nav-group *ngIf="item.subRoutes; else subRoutesElse"
                     class="go-nav-group__inner-group"
                     [navItem]="item">
       </go-nav-group>
       <ng-template #subRoutesElse>
-        <go-nav-item *ngIf="!item.subRoutes" [navItem]="item"></go-nav-item>
+        <go-nav-item [navItem]="item"></go-nav-item>
       </ng-template>
     </div>
   </div>

--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-group/go-nav-group.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewEncapsulation, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { NavGroup } from '../nav-group.model';
 import { NavItem } from '../nav-item.model';
 import { GoSideNavService } from '../go-side-nav/go-side-nav.service';
@@ -9,12 +9,19 @@ import { GoSideNavService } from '../go-side-nav/go-side-nav.service';
   styleUrls: ['./go-nav-group.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class GoNavGroupComponent {
+export class GoNavGroupComponent implements OnInit  {
   @Input() navItem: NavGroup | NavItem;
   @Input() class: string;
   @Output() closeNavs = new EventEmitter<NavGroup>();
 
+  group: NavGroup;
+
   constructor (public navService: GoSideNavService) { }
+
+  ngOnInit(): void {
+    // Using this to do type checking between NavGroup and NavItem in the html
+    this.group = this.navItem as NavGroup;
+  }
 
   expand(navGroup: NavGroup): void {
     navGroup.expanded = !navGroup.expanded;

--- a/projects/go-lib/src/lib/components/go-side-nav/nav-group.model.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/nav-group.model.ts
@@ -1,6 +1,7 @@
 import { NavItem } from './nav-item.model';
 
 export interface NavGroup {
+  description?: string;
   expanded?: boolean;
   routeIcon?: string;
   routeTitle: string;


### PR DESCRIPTION
When compiling the html for the navigation we are running into problems because we are checking if property exist, but they only exist for one type of item that we may have. In our component we have a dynamic type that could be either NavItem or NavGroup. We can either switch that type to be any or we can convert that dynamic type to be one of the two types and then do property checks on that.