### PR TITLE
GoTable always emits tableChange event, even in client mode.

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -54,7 +54,7 @@ export class GoTableComponent implements OnInit, OnChanges {
       this.setTotalCount();
       this.handleSort();
     }
-    
+
     this.showTable = Boolean(this.tableConfig);
     this.loadingData = false;
   }
@@ -93,9 +93,8 @@ export class GoTableComponent implements OnInit, OnChanges {
 
       this.localTableConfig.pageConfig.offset = 0;
 
-      if (this.isServerMode()) {
-        this.tableChange.emit(this.localTableConfig);
-      } else {
+      this.tableChange.emit(this.localTableConfig);
+      if (!this.isServerMode()) {
         this.handleSort();
         this.loadingData = false;
       }
@@ -170,7 +169,7 @@ export class GoTableComponent implements OnInit, OnChanges {
       return tableData.slice(pageConfig.offset, pageConfig.offset + pageConfig.perPage);
     }
   }
-  
+
   /** Private Methods **/
   private handleSort() : void {
     const { sortConfig, sortable, tableData } = this.localTableConfig;
@@ -201,9 +200,8 @@ export class GoTableComponent implements OnInit, OnChanges {
   }
 
   private tableChangeOutcome() : void {
-    if (this.isServerMode()) {
-      this.tableChange.emit(this.localTableConfig);
-    } else {
+    this.tableChange.emit(this.localTableConfig);
+    if (!this.isServerMode()) {
       this.loadingData = false;
     }
   }


### PR DESCRIPTION
When the GoTable is in client mode, there is no way to access the current local state of the configs (sort direction, page info, etc.). This means that when resetting the `tableConfig` binding to reset the data (for example when you have filtering implemented in the parent component) there is no way to maintain the current state of those configs.

I think ideally there should be a way to trigger the table to rerender without needed to pass in a whole new config object, perhaps exposing some setter methods or something like that, but in the meantime, this PR will allow you to receive the local table config from the `tableChange` event, regardless of what data mode you are, allowing the parent component to be able to use that state when rerendering the table.