### PR TITLE
Update table to not trigger loading inside of table component

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -56,7 +56,6 @@ export class GoTableComponent implements OnInit, OnChanges {
     }
 
     this.showTable = Boolean(this.tableConfig);
-    this.loadingData = false;
   }
 
   hasData() : boolean {
@@ -83,8 +82,6 @@ export class GoTableComponent implements OnInit, OnChanges {
     const { sortConfig, sortable, tableData } = this.localTableConfig;
 
     if (tableData && sortable) {
-      this.loadingData = true;
-
       if (sortConfig && sortConfig.column === columnField) {
         this.localTableConfig.sortConfig.direction = this.toggleSortDir(sortConfig.direction);
       } else {
@@ -96,13 +93,11 @@ export class GoTableComponent implements OnInit, OnChanges {
       this.tableChange.emit(this.localTableConfig);
       if (!this.isServerMode()) {
         this.handleSort();
-        this.loadingData = false;
       }
     }
   }
 
   nextPage() : void {
-    this.loadingData = true;
     this.localTableConfig.pageConfig.offset = this.localTableConfig.pageConfig.offset + this.localTableConfig.pageConfig.perPage;
 
     this.tableChangeOutcome();
@@ -117,7 +112,6 @@ export class GoTableComponent implements OnInit, OnChanges {
   setLastPage() : void {
     const { totalCount, pageConfig } = this.localTableConfig;
 
-    this.loadingData = true;
     let offset = totalCount - (totalCount % pageConfig.perPage);
     this.localTableConfig.pageConfig.offset = offset === totalCount ? totalCount - pageConfig.perPage : offset;
 
@@ -125,7 +119,6 @@ export class GoTableComponent implements OnInit, OnChanges {
   }
 
   prevPage() : void {
-    this.loadingData = true;
     this.localTableConfig.pageConfig.offset = this.localTableConfig.pageConfig.offset - this.localTableConfig.pageConfig.perPage;
 
     this.tableChangeOutcome();
@@ -136,14 +129,12 @@ export class GoTableComponent implements OnInit, OnChanges {
   }
 
   setFirstPage() : void {
-    this.loadingData = true;
     this.localTableConfig.pageConfig.offset = 0;
 
     this.tableChangeOutcome();
   }
 
   setPerPage(event: any) : void {
-    this.loadingData = true;
     this.localTableConfig.pageConfig.perPage = Number(event.target.value);
     this.localTableConfig.pageConfig.offset = 0;
 
@@ -201,8 +192,5 @@ export class GoTableComponent implements OnInit, OnChanges {
 
   private tableChangeOutcome() : void {
     this.tableChange.emit(this.localTableConfig);
-    if (!this.isServerMode()) {
-      this.loadingData = false;
-    }
   }
 }

--- a/projects/go-tester/src/app/components/test-page-1/test-page-1.component.ts
+++ b/projects/go-tester/src/app/components/test-page-1/test-page-1.component.ts
@@ -28,6 +28,7 @@ export class TestPage1Component implements OnInit {
 
   handleTableChange(currentTableConfig: GoTableConfig) : void {
     if (this.tableConfig.dataMode === GoTableDataSource.server) {
+      this.tableLoading = true;
       this.appService.getMockData(currentTableConfig).subscribe(data => {
         setTimeout(() => {
           currentTableConfig.tableData = data.results;


### PR DESCRIPTION
This PR updates the go-table-component to not trigger the loading spinner inside of the component for any reason. It will be the responsibility of the parent component to trigger the table updating from here on out.

The parent component can trigger this by updating the loadingData binding in the component

Fixes #107 