### PR TITLE
Go Input Component

### DIFF
--- a/projects/go-lib/src/lib/components/go-input/go-input.component.html
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.html
@@ -1,0 +1,22 @@
+<div [formGroup]="parentFormGroup">
+  <label [for]="controlName" class="go-form__label">
+    {{ label }}
+  </label>
+  <input [id]="controlName"
+         class="go-form__input"
+         [ngClass]="{'go-form__input--error': !controlIsValid()}"
+         [type]="inputType"
+         [placeholder]="placeholder"
+         [formControlName]="controlName">
+
+  <p *ngFor="let hint of hints" class="go-hint">
+    {{ hint }}
+  </p>
+
+  <ng-container *ngIf="!controlIsValid()">
+    <p class="go-hint go-hint--error" *ngFor="let error of errors">
+      <span class="go-hint__status">{{ errorStatus }}</span>
+      {{ error }}
+    </p>
+  </ng-container>
+</div>

--- a/projects/go-lib/src/lib/components/go-input/go-input.component.html
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.html
@@ -1,22 +1,25 @@
 <div [formGroup]="parentFormGroup">
-  <label [for]="controlName" class="go-form__label">
+  <label [for]="controlName"
+         class="go-form__label"
+         [ngClass]="{'go-form__label--dark': theme === 'dark'}">
     {{ label }}
   </label>
   <input [id]="controlName"
          class="go-form__input"
-         [ngClass]="{'go-form__input--error': !controlIsValid()}"
+         [ngClass]="{'go-form__input--error': !controlIsValid(), 'go-form__input--dark': theme === 'dark'}"
+         [attr.disabled]="inputDisabled ? '' : null"
          [type]="inputType"
          [placeholder]="placeholder"
          [formControlName]="controlName">
 
-  <p *ngFor="let hint of hints" class="go-hint">
+  <p *ngFor="let hint of hints" class="go-hint" [ngClass]="{'go-form__input--dark': theme === 'dark'}">
     {{ hint }}
   </p>
 
-  <ng-container *ngIf="!controlIsValid()">
+  <div [ngClass]="{'go-form__input--dark': theme === 'dark'}" *ngIf="!controlIsValid()">
     <p class="go-hint go-hint--error" *ngFor="let error of errors">
       <span class="go-hint__status">{{ errorStatus }}</span>
       {{ error }}
     </p>
-  </ng-container>
+  </div>
 </div>

--- a/projects/go-lib/src/lib/components/go-input/go-input.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GoInputComponent } from './go-input.component';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+describe('GoInputComponent', () => {
+  let component: GoInputComponent;
+  let fixture: ComponentFixture<GoInputComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [GoInputComponent],
+      imports: [FormsModule, ReactiveFormsModule]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GoInputComponent);
+    component = fixture.componentInstance;
+    component.controlName = 'testField';
+    component.parentFormGroup = new FormBuilder().group({
+      testField: ''
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/go-lib/src/lib/components/go-input/go-input.component.ts
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'go-input',
+  templateUrl: './go-input.component.html'
+})
+export class GoInputComponent {
+
+  @Input() label: string;
+  @Input() inputType: string = 'text';
+  @Input() errors: string[];
+  @Input() errorStatus: string = 'Error:';
+  @Input() hints: string[];
+  @Input() controlName: string;
+  @Input() parentFormGroup: FormGroup;
+  @Input() placeholder: string = '';
+
+  constructor() { }
+
+  controlIsValid(): boolean {
+    return !this.parentFormGroup.get(this.controlName).invalid;
+  }
+}

--- a/projects/go-lib/src/lib/components/go-input/go-input.component.ts
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.ts
@@ -1,22 +1,33 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'go-input',
   templateUrl: './go-input.component.html'
 })
-export class GoInputComponent {
+export class GoInputComponent implements OnInit {
 
-  @Input() label: string;
-  @Input() inputType: string = 'text';
+  @Input() controlName: string;
   @Input() errors: string[];
   @Input() errorStatus: string = 'Error:';
   @Input() hints: string[];
-  @Input() controlName: string;
+  @Input() inputDisabled: boolean;
+  @Input() inputType: string = 'text';
+  @Input() label: string;
   @Input() parentFormGroup: FormGroup;
   @Input() placeholder: string = '';
+  @Input() theme: string = 'light';
 
   constructor() { }
+
+  ngOnInit(): void {
+    if (!this.controlName) {
+      throw new Error('GoInput: controlName is a required Input');
+    }
+    if (!this.parentFormGroup) {
+      throw new Error('GoInput: parentFormGroup is a required Input');
+    }
+  }
 
   controlIsValid(): boolean {
     return !this.parentFormGroup.get(this.controlName).invalid;

--- a/projects/go-lib/src/lib/components/go-input/go-input.module.ts
+++ b/projects/go-lib/src/lib/components/go-input/go-input.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { GoInputComponent } from './go-input.component';
+
+@NgModule({
+  declarations: [GoInputComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule
+  ],
+  exports: [GoInputComponent]
+})
+
+export class GoInputModule { }

--- a/projects/go-lib/src/lib/go-shared.module.ts
+++ b/projects/go-lib/src/lib/go-shared.module.ts
@@ -14,6 +14,7 @@ import { GoToastModule } from './components/go-toast/go-toast.module';
 import { GoIconButtonModule } from './components/go-icon-button/go-icon-button.module';
 import { GoToasterModule } from './components/go-toaster/go-toaster.module';
 import { GoActionSheetModule } from './components/go-action-sheet/go-action-sheet.module';
+import { GoInputModule } from './components/go-input/go-input.module';
 
 @NgModule({
   imports: [
@@ -24,6 +25,7 @@ import { GoActionSheetModule } from './components/go-action-sheet/go-action-shee
     GoHeaderModule,
     GoIconButtonModule,
     GoIconModule,
+    GoInputModule,
     GoLayoutModule,
     GoLoaderModule,
     GoModalModule,
@@ -40,6 +42,7 @@ import { GoActionSheetModule } from './components/go-action-sheet/go-action-shee
     GoHeaderModule,
     GoIconButtonModule,
     GoIconModule,
+    GoInputModule,
     GoLayoutModule,
     GoLoaderModule,
     GoModalModule,

--- a/projects/go-lib/src/public_api.ts
+++ b/projects/go-lib/src/public_api.ts
@@ -34,6 +34,10 @@ export * from './lib/components/go-icon/go-icon.module';
 export * from './lib/components/go-icon-button/go-icon-button.component';
 export * from './lib/components/go-icon-button/go-icon-button.module';
 
+// Input
+export * from './lib/components/go-input/go-input.component';
+export * from './lib/components/go-input/go-input.module';
+
 // Layout
 export * from './lib/components/go-layout/go-layout.component';
 export * from './lib/components/go-layout/go-layout.module';

--- a/projects/go-tester/src/app/app-routing.module.ts
+++ b/projects/go-tester/src/app/app-routing.module.ts
@@ -3,12 +3,14 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { TestPage1Component } from './components/test-page-1/test-page-1.component';
 import { TestPage2Component } from './components/test-page-2/test-page-2.component';
+import { TestPage3Component } from './components/test-page-3/test-page-3.component';
 import { AppGuard } from './app.guard';
 
 const routes: Routes = [
   { path: '', redirectTo: 'test-page-1', pathMatch: 'full' },
   { path: 'test-page-1', component: TestPage1Component, canActivate: [AppGuard] },
-  { path: 'test-page-2', component: TestPage2Component, canActivate: [AppGuard]}
+  { path: 'test-page-2', component: TestPage2Component, canActivate: [AppGuard]},
+  { path: 'test-page-3', component: TestPage3Component, canActivate: [AppGuard]}
 ];
 
 @NgModule({

--- a/projects/go-tester/src/app/app.component.ts
+++ b/projects/go-tester/src/app/app.component.ts
@@ -23,7 +23,8 @@ export class AppComponent implements OnInit {
   menuItems: Array<NavGroup | NavItem> = [
     { routeIcon: 'dashboard', routeTitle: 'Tests', description: 'Test Routes', subRoutes: [
       { route: 'test-page-1', routeTitle: 'Test 1', description: 'Test Route 1' },
-      { route: 'test-page-2', routeTitle: 'Test 2' }
+      { route: 'test-page-2', routeTitle: 'Test 2' },
+      { route: 'test-page-3', routeTitle: 'Test 3', description: 'Forms' }
     ]}
   ];
 

--- a/projects/go-tester/src/app/app.module.ts
+++ b/projects/go-tester/src/app/app.module.ts
@@ -2,24 +2,27 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import {
+  GoAccordionModule,
+  GoActionSheetModule,
   GoButtonComponent,
   GoButtonModule,
+  GoCardModule,
   GoHeaderModule,
   GoIconButtonModule,
   GoIconComponent,
   GoIconModule,
+  GoInputModule,
   GoLayoutModule,
   GoLoaderModule,
   GoOffCanvasModule,
   GoSearchModule,
   GoSideNavModule,
   GoTableModule,
-  GoToastModule,
   GoToasterModule,
-  GoActionSheetModule,
-  GoAccordionModule
+  GoToastModule
 } from '../../../go-lib/src/public_api';
 
 import { AppRoutesModule } from './app-routing.module';
@@ -30,26 +33,31 @@ import { SearchTestComponent } from './components/search-test/search-test.compon
 import { TestPage1Component } from './components/test-page-1/test-page-1.component';
 import { TestPage2Component } from './components/test-page-2/test-page-2.component';
 import { AppGuard } from './app.guard';
-
+import { TestPage3Component } from './components/test-page-3/test-page-3.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     SearchTestComponent,
     TestPage1Component,
-    TestPage2Component
+    TestPage2Component,
+    TestPage3Component
   ],
   imports: [
     AppRoutesModule,
     BrowserModule,
     BrowserAnimationsModule,
+    FormsModule,
+    ReactiveFormsModule,
     HttpClientModule,
     GoAccordionModule,
     GoActionSheetModule,
     GoButtonModule,
+    GoCardModule,
     GoHeaderModule,
     GoIconModule,
     GoIconButtonModule,
+    GoInputModule,
     GoLayoutModule,
     GoLoaderModule,
     GoOffCanvasModule,

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -1,0 +1,33 @@
+<section class="go-container">
+  <div class="go-column go-column--100">
+    <h2 class="go-heading-2">
+      Form
+    </h2>
+    <hr>
+  </div>
+  <div class="go-column go-column--100">
+    <go-card>
+      <ng-container go-card-content>
+        <form [formGroup]="form" (ngSubmit)="onSubmit()" class="go-form" *ngIf="form">
+          <section class="go-container">
+            <div class="go-column go-column--50">
+              <go-input controlName="name"
+                        label="Name"
+                        [hints]="['we need your full name here']"
+                        [parentFormGroup]="form"
+                        [errors]="formErrors.name">
+              </go-input>
+            </div>
+
+            <div class="go-column go-column--100">
+              <go-button buttonType='submit'
+                         buttonVariant='positive'>
+                Save
+              </go-button>
+            </div>
+          </section>
+        </form>
+      </ng-container>
+    </go-card>
+  </div>
+</section>

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-test-page-3',
+  templateUrl: './test-page-3.component.html'
+})
+export class TestPage3Component implements OnInit {
+  formErrors: {[k: string]: string[]} = {};
+  form: FormGroup;
+
+  constructor(
+    private fb: FormBuilder
+  ) { }
+
+  ngOnInit(): void {
+    this.buildForm();
+  }
+
+  onSubmit(): void {
+    if (this.formErrors.name) {
+      this.formErrors.name = null;
+      this.form.get('name').setErrors(null);
+    } else {
+      this.formErrors.name = ['This is an invalid name'];
+      this.form.get('name').setErrors({ name: 'invalid' });
+    }
+  }
+
+  private buildForm(): void {
+    this.form = this.fb.group({
+      name: new FormControl()
+    });
+  }
+}


### PR DESCRIPTION
Closes #119 

This adds an input component with a few bindings to allow for the use within reactive forms. It allows you to pass in both hints and errors to be displayed. It puts the responsibility of validation on the parent component allowing the implementor to have full control over the input.