### PR TITLE
Go Textarea Component

### DIFF
--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.html
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.html
@@ -1,22 +1,26 @@
 <div [formGroup]="parentFormGroup">
-  <label [for]="controlName" class="go-form__label">
+  <label [for]="controlName"
+         class="go-form__label"
+         [ngClass]="{'go-form__label--dark': theme === 'dark'}">
     {{ label }}
   </label>
   <textarea [id]="controlName"
             class="go-form__input"
-            [ngClass]="{'go-form__input--error': !controlIsValid(), 'go-form__input--disabled': inputDisabled}"
+            [ngClass]="{'go-form__input--error': !controlIsValid(), 'go-form__input--dark': theme === 'dark'}"
             [attr.disabled]="inputDisabled ? '' : null"
             [placeholder]="placeholder"
             [formControlName]="controlName"></textarea>
 
-  <p *ngFor="let hint of hints" class="go-hint">
+  <p *ngFor="let hint of hints"
+     class="go-hint"
+     [ngClass]="{'go-form__input--dark': theme === 'dark'}">
     {{ hint }}
   </p>
 
-  <ng-container *ngIf="!controlIsValid()">
+  <div *ngIf="!controlIsValid()" [ngClass]="{'go-form__input--dark': theme === 'dark'}">
     <p class="go-hint go-hint--error" *ngFor="let error of errors">
       <span class="go-hint__status">{{ errorStatus }}</span>
       {{ error }}
     </p>
-  </ng-container>
+  </div>
 </div>

--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.html
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.html
@@ -1,0 +1,22 @@
+<div [formGroup]="parentFormGroup">
+  <label [for]="controlName" class="go-form__label">
+    {{ label }}
+  </label>
+  <textarea [id]="controlName"
+            class="go-form__input"
+            [ngClass]="{'go-form__input--error': !controlIsValid(), 'go-form__input--disabled': inputDisabled}"
+            [attr.disabled]="inputDisabled ? '' : null"
+            [placeholder]="placeholder"
+            [formControlName]="controlName"></textarea>
+
+  <p *ngFor="let hint of hints" class="go-hint">
+    {{ hint }}
+  </p>
+
+  <ng-container *ngIf="!controlIsValid()">
+    <p class="go-hint go-hint--error" *ngFor="let error of errors">
+      <span class="go-hint__status">{{ errorStatus }}</span>
+      {{ error }}
+    </p>
+  </ng-container>
+</div>

--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.spec.ts
@@ -1,0 +1,33 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GoTextAreaComponent } from './go-text-area.component';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+describe('GoTextAreaComponent', () => {
+  let component: GoTextAreaComponent;
+  let fixture: ComponentFixture<GoTextAreaComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [GoTextAreaComponent],
+      imports: [FormsModule, ReactiveFormsModule]
+
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GoTextAreaComponent);
+    component = fixture.componentInstance;
+    component.parentFormGroup = new FormBuilder().group({
+      testField: ''
+    });
+
+    component.controlName = 'testField';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.ts
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'go-text-area',
+  templateUrl: './go-text-area.component.html'
+})
+export class GoTextAreaComponent {
+
+  @Input() label: string;
+  @Input() errors: string[];
+  @Input() errorStatus: string = 'Error:';
+  @Input() hints: string[];
+  @Input() inputDisabled: boolean;
+  @Input() controlName: string;
+  @Input() parentFormGroup: FormGroup;
+  @Input() placeholder: string = '';
+
+  constructor() { }
+
+  controlIsValid(): boolean {
+    return !this.parentFormGroup.get(this.controlName).invalid;
+  }
+}

--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.ts
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.ts
@@ -7,14 +7,15 @@ import { FormGroup } from '@angular/forms';
 })
 export class GoTextAreaComponent {
 
-  @Input() label: string;
+  @Input() controlName: string;
   @Input() errors: string[];
   @Input() errorStatus: string = 'Error:';
   @Input() hints: string[];
   @Input() inputDisabled: boolean;
-  @Input() controlName: string;
+  @Input() label: string;
   @Input() parentFormGroup: FormGroup;
   @Input() placeholder: string = '';
+  @Input() theme: string = 'light';
 
   constructor() { }
 

--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.module.ts
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { GoTextAreaComponent } from './go-text-area.component';
+
+@NgModule({
+  declarations: [GoTextAreaComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule
+  ],
+  exports: [GoTextAreaComponent]
+})
+
+export class GoTextAreaModule { }

--- a/projects/go-lib/src/lib/go-shared.module.ts
+++ b/projects/go-lib/src/lib/go-shared.module.ts
@@ -15,6 +15,7 @@ import { GoIconButtonModule } from './components/go-icon-button/go-icon-button.m
 import { GoToasterModule } from './components/go-toaster/go-toaster.module';
 import { GoActionSheetModule } from './components/go-action-sheet/go-action-sheet.module';
 import { GoInputModule } from './components/go-input/go-input.module';
+import { GoTextAreaModule } from './components/go-text-area/go-text-area.module';
 
 @NgModule({
   imports: [
@@ -32,6 +33,7 @@ import { GoInputModule } from './components/go-input/go-input.module';
     GoSearchModule,
     GoSideNavModule,
     GoTableModule,
+    GoTextAreaModule,
     GoToastModule,
     GoToasterModule
   ],
@@ -49,6 +51,7 @@ import { GoInputModule } from './components/go-input/go-input.module';
     GoSearchModule,
     GoSideNavModule,
     GoTableModule,
+    GoTextAreaModule,
     GoToastModule,
     GoToasterModule
   ]

--- a/projects/go-lib/src/public_api.ts
+++ b/projects/go-lib/src/public_api.ts
@@ -75,6 +75,10 @@ export * from './lib/components/go-table/go-table-config.model';
 export * from './lib/components/go-table/go-table-sort.model';
 export * from './lib/components/go-table/go-table-paging.model';
 
+// Text Area
+export * from './lib/components/go-text-area/go-text-area.component';
+export * from './lib/components/go-text-area/go-text-area.module';
+
 // Toast
 export * from './lib/components/go-toast/go-toast.component';
 export * from './lib/components/go-toast/go-toast.module';

--- a/projects/go-tester/src/app/app.module.ts
+++ b/projects/go-tester/src/app/app.module.ts
@@ -21,6 +21,7 @@ import {
   GoSearchModule,
   GoSideNavModule,
   GoTableModule,
+  GoTextAreaModule,
   GoToasterModule,
   GoToastModule
 } from '../../../go-lib/src/public_api';
@@ -32,8 +33,8 @@ import { AppService } from './app.service';
 import { SearchTestComponent } from './components/search-test/search-test.component';
 import { TestPage1Component } from './components/test-page-1/test-page-1.component';
 import { TestPage2Component } from './components/test-page-2/test-page-2.component';
-import { AppGuard } from './app.guard';
 import { TestPage3Component } from './components/test-page-3/test-page-3.component';
+import { AppGuard } from './app.guard';
 
 @NgModule({
   declarations: [
@@ -50,6 +51,8 @@ import { TestPage3Component } from './components/test-page-3/test-page-3.compone
     FormsModule,
     ReactiveFormsModule,
     HttpClientModule,
+    FormsModule,
+    ReactiveFormsModule,
     GoAccordionModule,
     GoActionSheetModule,
     GoButtonModule,
@@ -64,6 +67,7 @@ import { TestPage3Component } from './components/test-page-3/test-page-3.compone
     GoSearchModule,
     GoSideNavModule,
     GoTableModule,
+    GoTextAreaModule,
     GoToastModule,
     GoToasterModule
   ],

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -18,7 +18,7 @@
                         [errors]="formErrors.name">
               </go-input>
               <go-text-area controlName="notes"
-                            label="Name"
+                            label="Notes"
                             [hints]="['Give us a full description']"
                             [parentFormGroup]="form"
                             [errors]="formErrors.notes">

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -17,6 +17,12 @@
                         [parentFormGroup]="form"
                         [errors]="formErrors.name">
               </go-input>
+              <go-text-area controlName="notes"
+                            label="Name"
+                            [hints]="['Give us a full description']"
+                            [parentFormGroup]="form"
+                            [errors]="formErrors.notes">
+              </go-text-area>
             </div>
 
             <div class="go-column go-column--100">

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
@@ -18,19 +18,17 @@ export class TestPage3Component implements OnInit {
   }
 
   onSubmit(): void {
-    if (this.formErrors.name) {
-      this.formErrors.name = null;
-      this.form.get('name').setErrors(null);
+    this.setError('name', 'This is an invalid name');
+    this.setError('notes', 'This is an invalid desciption');
+  }
+
+  private setError(formControlName: string, errorMessage: string): void {
+    if (this.formErrors[formControlName]) {
+      this.formErrors[formControlName] = null;
+      this.form.get(formControlName).setErrors(null);
     } else {
-      this.formErrors.name = ['This is an invalid name'];
-      this.form.get('name').setErrors({ name: 'invalid' });
-    }
-    if (this.formErrors.notes) {
-      this.formErrors.notes = null;
-      this.form.get('notes').setErrors(null);
-    } else {
-      this.formErrors.notes = ['This is an invalid desciption'];
-      this.form.get('notes').setErrors({ errors: 'invalid' });
+      this.formErrors[formControlName] = [errorMessage];
+      this.form.get(formControlName).setErrors({ errors: 'invalid' });
     }
   }
 

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
@@ -25,11 +25,19 @@ export class TestPage3Component implements OnInit {
       this.formErrors.name = ['This is an invalid name'];
       this.form.get('name').setErrors({ name: 'invalid' });
     }
+    if (this.formErrors.notes) {
+      this.formErrors.notes = null;
+      this.form.get('notes').setErrors(null);
+    } else {
+      this.formErrors.notes = ['This is an invalid desciption'];
+      this.form.get('notes').setErrors({ errors: 'invalid' });
+    }
   }
 
   private buildForm(): void {
     this.form = this.fb.group({
-      name: new FormControl()
+      name: [''],
+      notes: ['']
     });
   }
 }


### PR DESCRIPTION
Closes #120

This adds a textarea component with a few bindings to allow for the use within reactive forms. It allows you to pass in both hints and errors to be displayed. It puts the responsibility of validation on the parent component allowing the implementor to have full control over the textarea.