### PR TITLE
Manually updates classes when state changes to increase performance

### DIFF
--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
@@ -1,11 +1,11 @@
 <section
   class="go-accordion-panel"
-  [ngClass]="containerClasses()"
+  [ngClass]="containerClasses"
 >
   <header
     aria-expanded="expanded"
     class="go-accordion-panel__header"
-    [ngClass]="headerClasses()"
+    [ngClass]="headerClasses"
     (click)="toggle.emit()"
   >
     <div class="go-accordion-panel__title">

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
@@ -3,7 +3,7 @@
   [ngClass]="containerClasses"
 >
   <header
-    aria-expanded="expanded"
+    [attr.aria-expanded]="_expanded"
     class="go-accordion-panel__header"
     [ngClass]="headerClasses"
     (click)="toggle.emit()"
@@ -20,11 +20,11 @@
     <go-icon
       class="go-accordion-panel__control"
       icon="expand_more"
-      [ngClass]="{'go-accordion-panel__control--active': expanded}"
+      [ngClass]="{'go-accordion-panel__control--active': _expanded}"
     ></go-icon>
   </header>
 
-  <div [@accordionAnimation]="expanded ? 'open' : 'close'">
+  <div [@accordionAnimation]="_expanded ? 'open' : 'close'">
     <div
       class="go-accordion-panel__content"
       [ngClass]="{'go-accordion-panel__content--slim': slim }"

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
@@ -128,11 +128,6 @@
   color: $theme-dark-color;
   font-weight: 300;
 
-  go-accordion-panel:not(:first-of-type) .go-accordion-panel__header,
-  go-accordion-panel:last-of-type .go-accordion-panel__header {
-    border-top: 1px solid $theme-dark-border;
-  }
-
   .go-accordion-panel--border-top .go-accordion-panel__header {
     border-top: 1px solid $theme-dark-border;
   }

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.spec.ts
@@ -50,10 +50,34 @@ describe('GoAccordionPanelComponent', () => {
     });
   });
 
+  describe('expanded', () => {
+    it('sets _expanded', () => {
+      expect(component._expanded).toBe(false);
+
+      component.expanded = true;
+
+      expect(component._expanded).toBe(true);
+    });
+
+    it('gets _expanded', () => {
+      expect(component.expanded).toBe(component._expanded);
+    });
+
+    it('sets modifier classes', () => {
+      expect(component.containerClasses['go-accordion-panel--active']).toBeFalsy();
+      expect(component.headerClasses['go-accordion-panel__header--active']).toBeFalsy();
+
+      component.expanded = true;
+
+      expect(component.containerClasses['go-accordion-panel--active']).toBe(true);
+      expect(component.headerClasses['go-accordion-panel__header--active']).toBe(true);
+    });
+  });
+
   describe('updateClasses()', () => {
     beforeEach(() => {
-      expect(component.containerClasses).toBeUndefined();
-      expect(component.headerClasses).toBeUndefined();
+      expect(component.containerClasses).toEqual({});
+      expect(component.headerClasses).toEqual({});
     });
 
     describe('containerClasses', () => {
@@ -66,7 +90,7 @@ describe('GoAccordionPanelComponent', () => {
       });
 
       it('sets the go-accordion-panel--active class if expanded is true', () => {
-        component.expanded = true;
+        component._expanded = true;
 
         component.updateClasses();
 
@@ -100,7 +124,7 @@ describe('GoAccordionPanelComponent', () => {
 
     describe('headerClasses', () => {
       it('sets the go-accordion-panel__header--active class if expanded is true', () => {
-        component.expanded = true;
+        component._expanded = true;
 
         component.updateClasses();
 

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.spec.ts
@@ -40,89 +40,88 @@ describe('GoAccordionPanelComponent', () => {
     });
   });
 
-  describe('containerClasses', () => {
-    beforeEach(() => {
-      expect(component.containerClasses()).toEqual({
-        'go-accordion-panel--borderless': false,
-        'go-accordion-panel--dark': false,
-        'go-accordion-panel--active': false,
-        'go-accordion-panel--first': false,
-        'go-accordion-panel--last': false
-      });
-    });
+  describe('ngOnChanges', () => {
+    it('calls updateClasses()', () => {
+      spyOn(component, 'updateClasses');
 
-    it('sets the go-accordion-panel--borderless class if borderless is true', () => {
-      component.borderless = true;
+      component.ngOnChanges();
 
-      const containerClasses: object = component.containerClasses();
-
-      expect(containerClasses['go-accordion-panel--borderless']).toBe(true);
-    });
-
-    it('sets the go-accordion-panel--active class if expanded is true', () => {
-      component.expanded = true;
-
-      const containerClasses: object = component.containerClasses();
-
-      expect(containerClasses['go-accordion-panel--active']).toBe(true);
-    });
-
-    it('sets the go-accordion-panel--dark class if theme is "dark"', () => {
-      component.theme = 'dark';
-
-      const containerClasses: object = component.containerClasses();
-
-      expect(containerClasses['go-accordion-panel--dark']).toBe(true);
-    });
-
-    it('sets the go-accordion-panel--first class if expanded is true', () => {
-      component.isFirst = true;
-
-      const containerClasses: object = component.containerClasses();
-
-      expect(containerClasses['go-accordion-panel--first']).toBe(true);
-    });
-
-    it('sets the go-accordion-panel--last class if expanded is true', () => {
-      component.isLast = true;
-
-      const containerClasses: object = component.containerClasses();
-
-      expect(containerClasses['go-accordion-panel--last']).toBe(true);
+      expect(component.updateClasses).toHaveBeenCalled();
     });
   });
 
-  describe('headerClasses', () => {
+  describe('updateClasses()', () => {
     beforeEach(() => {
-      expect(component.headerClasses()).toEqual({
-        'go-accordion-panel__header--active': false,
-        'go-accordion-panel__header--dark': false,
-        'go-accordion-panel__header--slim': false
+      expect(component.containerClasses).toBeUndefined();
+      expect(component.headerClasses).toBeUndefined();
+    });
+
+    describe('containerClasses', () => {
+      it('sets the go-accordion-panel--borderless class if borderless is true', () => {
+        component.borderless = true;
+
+        component.updateClasses();
+
+        expect(component.containerClasses['go-accordion-panel--borderless']).toBe(true);
+      });
+
+      it('sets the go-accordion-panel--active class if expanded is true', () => {
+        component.expanded = true;
+
+        component.updateClasses();
+
+        expect(component.containerClasses['go-accordion-panel--active']).toBe(true);
+      });
+
+      it('sets the go-accordion-panel--dark class if theme is "dark"', () => {
+        component.theme = 'dark';
+
+        component.updateClasses();
+
+        expect(component.containerClasses['go-accordion-panel--dark']).toBe(true);
+      });
+
+      it('sets the go-accordion-panel--first class if expanded is true', () => {
+        component.isFirst = true;
+
+        component.updateClasses();
+
+        expect(component.containerClasses['go-accordion-panel--first']).toBe(true);
+      });
+
+      it('sets the go-accordion-panel--last class if expanded is true', () => {
+        component.isLast = true;
+
+        component.updateClasses();
+
+        expect(component.containerClasses['go-accordion-panel--last']).toBe(true);
       });
     });
 
-    it('sets the go-accordion-panel__header--active class if expanded is true', () => {
-      component.expanded = true;
+    describe('headerClasses', () => {
+      it('sets the go-accordion-panel__header--active class if expanded is true', () => {
+        component.expanded = true;
 
-      const headerClasses: object = component.headerClasses();
+        component.updateClasses();
 
-      expect(headerClasses['go-accordion-panel__header--active']).toBe(true);
-    });
+        expect(component.headerClasses['go-accordion-panel__header--active']).toBe(true);
+      });
 
-    it('sets the go-accordion-panel__header--dark class if theme is dark', () => {
-      component.theme = 'dark';
+      it('sets the go-accordion-panel__header--dark class if theme is dark', () => {
+        component.theme = 'dark';
 
-      const headerClasses: object = component.headerClasses();
+        component.updateClasses();
 
-      expect(headerClasses['go-accordion-panel__header--dark']).toBe(true);
-    });
+        expect(component.headerClasses['go-accordion-panel__header--dark']).toBe(true);
+      });
 
-    it('sets the go-accordion-panel__header--slim class if slim is true', () => {
-      component.slim = true;
+      it('sets the go-accordion-panel__header--slim class if slim is true', () => {
+        component.slim = true;
 
-      const headerClasses: object = component.headerClasses();
+        component.updateClasses();
 
-      expect(headerClasses['go-accordion-panel__header--slim']).toBe(true);
+        expect(component.headerClasses['go-accordion-panel__header--slim']).toBe(true);
+      });
     });
   });
 

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
@@ -19,8 +19,11 @@ import { accordionAnimation } from '../../animations/accordion.animation';
   ]
 })
 export class GoAccordionPanelComponent implements OnInit, OnChanges {
+  _expanded: boolean = false; // Note: Use _expanded in the template
+  containerClasses: object = {};
+  headerClasses: object = {};
+
   @Input() borderless: boolean;
-  @Input() expanded: boolean = false;
   @Input() heading: string;
   @Input() icon: string = null;
   @Input() isFirst: boolean = false;
@@ -29,10 +32,17 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
   @Input() theme: 'dark' | 'light';
   @Input() title: string;
 
-  @Output() toggle: EventEmitter<void> = new EventEmitter<void>();
+  @Input()
+  set expanded(expanded: boolean) {
+    this._expanded = expanded;
+    this.containerClasses['go-accordion-panel--active'] = expanded;
+    this.headerClasses['go-accordion-panel__header--active'] = expanded;
+  }
+  get expanded(): boolean {
+    return this._expanded;
+  }
 
-  containerClasses: object;
-  headerClasses: object;
+  @Output() toggle: EventEmitter<void> = new EventEmitter<void>();
 
   constructor() { }
 

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
@@ -4,7 +4,8 @@ import {
   Input,
   OnInit,
   Output,
-  ViewEncapsulation
+  ViewEncapsulation,
+  OnChanges
 } from '@angular/core';
 
 import { accordionAnimation } from '../../animations/accordion.animation';
@@ -17,7 +18,7 @@ import { accordionAnimation } from '../../animations/accordion.animation';
     accordionAnimation
   ]
 })
-export class GoAccordionPanelComponent implements OnInit {
+export class GoAccordionPanelComponent implements OnInit, OnChanges {
   @Input() borderless: boolean;
   @Input() expanded: boolean = false;
   @Input() heading: string;
@@ -30,6 +31,9 @@ export class GoAccordionPanelComponent implements OnInit {
 
   @Output() toggle: EventEmitter<void> = new EventEmitter<void>();
 
+  containerClasses: object;
+  headerClasses: object;
+
   constructor() { }
 
   ngOnInit(): void {
@@ -37,18 +41,20 @@ export class GoAccordionPanelComponent implements OnInit {
     this.heading = this.heading || this.title;
   }
 
-  containerClasses(): object {
-    return {
+  ngOnChanges(): void {
+    this.updateClasses();
+  }
+
+  updateClasses(): void {
+    this.containerClasses = {
       'go-accordion-panel--active': this.expanded === true,
       'go-accordion-panel--borderless': this.borderless === true,
       'go-accordion-panel--dark': this.theme === 'dark',
       'go-accordion-panel--first': this.isFirst === true,
       'go-accordion-panel--last': this.isLast === true,
     };
-  }
 
-  headerClasses(): object {
-    return {
+    this.headerClasses = {
       'go-accordion-panel__header--active': this.expanded === true,
       'go-accordion-panel__header--dark': this.theme === 'dark',
       'go-accordion-panel__header--slim': this.slim === true

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.spec.ts
@@ -78,6 +78,14 @@ describe('AccordionComponent', () => {
       panelTwo.slim = undefined;
       panelOne.borderless = undefined;
       panelTwo.borderless = undefined;
+
+      spyOn(panelOne, 'updateClasses');
+      spyOn(panelTwo, 'updateClasses');
+    });
+
+    afterEach(() => {
+      expect(panelOne.updateClasses).toHaveBeenCalled();
+      expect(panelTwo.updateClasses).toHaveBeenCalled();
     });
 
     it('subscribes to each panels toggle event', () => {
@@ -171,12 +179,14 @@ describe('AccordionComponent', () => {
 
     it('sets isFirst to true and isLast to false on the first panel in the accordion', () => {
       expect(component.panels.length).toBe(2);
+      component.ngAfterContentInit();
       expect(panelOne.isFirst).toBe(true);
       expect(panelOne.isLast).toBe(false);
     });
 
     it('sets isFirst to false and isLast to true on the last panel in the accordion', () => {
       expect(component.panels.length).toBe(2);
+      component.ngAfterContentInit();
       expect(panelTwo.isFirst).toBe(false);
       expect(panelTwo.isLast).toBe(true);
     });
@@ -212,18 +222,28 @@ describe('AccordionComponent', () => {
           isn't a toggle event emitter on the panel.
         `);
       }
+
+      spyOn(panelOne, 'updateClasses');
+      spyOn(panelTwo, 'updateClasses');
     });
 
     it('closes if it is open', () => {
       expect(panelOne.expanded).toBe(false);
+
       panelOne.toggle.emit();
+
       expect(panelOne.expanded).toBe(true);
+      expect(panelOne.updateClasses).toHaveBeenCalled();
+      expect(panelTwo.updateClasses).toHaveBeenCalled();
     });
 
     it('opens if it is closed', () => {
       panelOne.expanded = true;
+
       panelOne.toggle.emit();
+
       expect(panelOne.expanded).toBe(false);
+      expect(panelOne.updateClasses).toHaveBeenCalled();
     });
 
     describe('if multiExpand is false', () => {
@@ -240,6 +260,8 @@ describe('AccordionComponent', () => {
 
         expect(panelOne.expanded).toBe(false);
         expect(panelTwo.expanded).toBe(true);
+        expect(panelOne.updateClasses).toHaveBeenCalled();
+        expect(panelTwo.updateClasses).toHaveBeenCalled();
       });
     });
 
@@ -257,6 +279,7 @@ describe('AccordionComponent', () => {
 
         expect(panelOne.expanded).toBe(true);
         expect(panelTwo.expanded).toBe(true);
+        expect(panelTwo.updateClasses).toHaveBeenCalled();
       });
     });
   });

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.spec.ts
@@ -222,9 +222,6 @@ describe('AccordionComponent', () => {
           isn't a toggle event emitter on the panel.
         `);
       }
-
-      spyOn(panelOne, 'updateClasses');
-      spyOn(panelTwo, 'updateClasses');
     });
 
     it('closes if it is open', () => {
@@ -233,8 +230,6 @@ describe('AccordionComponent', () => {
       panelOne.toggle.emit();
 
       expect(panelOne.expanded).toBe(true);
-      expect(panelOne.updateClasses).toHaveBeenCalled();
-      expect(panelTwo.updateClasses).toHaveBeenCalled();
     });
 
     it('opens if it is closed', () => {
@@ -243,7 +238,6 @@ describe('AccordionComponent', () => {
       panelOne.toggle.emit();
 
       expect(panelOne.expanded).toBe(false);
-      expect(panelOne.updateClasses).toHaveBeenCalled();
     });
 
     describe('if multiExpand is false', () => {
@@ -260,8 +254,6 @@ describe('AccordionComponent', () => {
 
         expect(panelOne.expanded).toBe(false);
         expect(panelTwo.expanded).toBe(true);
-        expect(panelOne.updateClasses).toHaveBeenCalled();
-        expect(panelTwo.updateClasses).toHaveBeenCalled();
       });
     });
 
@@ -279,7 +271,6 @@ describe('AccordionComponent', () => {
 
         expect(panelOne.expanded).toBe(true);
         expect(panelTwo.expanded).toBe(true);
-        expect(panelTwo.updateClasses).toHaveBeenCalled();
       });
     });
   });

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.ts
@@ -47,6 +47,7 @@ export class GoAccordionComponent implements OnInit, AfterContentInit {
       // NOTE: This feels a little destructive.
       // We lose track of the icon explicitly set by the child component.
       panel.icon = this.showIcons ? panel.icon : null;
+      panel.updateClasses();
     });
   }
   //#endregion
@@ -74,10 +75,12 @@ export class GoAccordionComponent implements OnInit, AfterContentInit {
 
   private openPanel(panel: GoAccordionPanelComponent): void {
     panel.expanded = true;
+    panel.updateClasses();
   }
 
   private closePanel(panel: GoAccordionPanelComponent): void {
     panel.expanded = false;
+    panel.updateClasses();
   }
   //#endregion
 }

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.ts
@@ -35,19 +35,8 @@ export class GoAccordionComponent implements OnInit, AfterContentInit {
 
   ngAfterContentInit(): void {
     this.panels.toArray().forEach((panel: GoAccordionPanelComponent, index: number) => {
+      this.updatePanelState(panel, index);
       this.subscribePanel(panel);
-
-      panel.borderless = panel.borderless === undefined ? this.borderless : panel.borderless;
-      panel.slim = panel.slim === undefined ? this.slim : panel.slim;
-      panel.theme = panel.theme || this.theme;
-      panel.isFirst = index === 0;
-      panel.isLast = index === (this.panels.length - 1);
-      panel.expanded = this.expandAll || panel.expanded;
-
-      // NOTE: This feels a little destructive.
-      // We lose track of the icon explicitly set by the child component.
-      panel.icon = this.showIcons ? panel.icon : null;
-      panel.updateClasses();
     });
   }
   //#endregion
@@ -58,28 +47,29 @@ export class GoAccordionComponent implements OnInit, AfterContentInit {
   private subscribePanel(panel: GoAccordionPanelComponent): void {
     panel.toggle.subscribe(() => {
       if (!panel.expanded && this.multiExpand) {
-        this.openPanel(panel);
+        panel.expanded = true;
       } else if (!panel.expanded && !this.multiExpand) {
-        this.openPanelCloseOthers(panel);
+        this.panels.toArray().forEach((thePanel: GoAccordionPanelComponent) => {
+          thePanel.expanded = false;
+        });
+        panel.expanded = true;
       } else {
-        this.closePanel(panel);
+        panel.expanded = false;
       }
     });
   }
 
-  private openPanelCloseOthers(panel: GoAccordionPanelComponent): void {
-    this.panels.toArray().forEach(this.closePanel);
+  private updatePanelState(panel: GoAccordionPanelComponent, index: number): void {
+    panel.borderless = panel.borderless === undefined ? this.borderless : panel.borderless;
+    panel.slim = panel.slim === undefined ? this.slim : panel.slim;
+    panel.theme = panel.theme || this.theme;
+    panel.isFirst = index === 0;
+    panel.isLast = index === (this.panels.length - 1);
+    panel.expanded = this.expandAll || panel.expanded;
 
-    this.openPanel(panel);
-  }
-
-  private openPanel(panel: GoAccordionPanelComponent): void {
-    panel.expanded = true;
-    panel.updateClasses();
-  }
-
-  private closePanel(panel: GoAccordionPanelComponent): void {
-    panel.expanded = false;
+    // NOTE: This feels a little destructive.
+    // We lose track of the icon explicitly set by the child component.
+    panel.icon = this.showIcons ? panel.icon : null;
     panel.updateClasses();
   }
   //#endregion

--- a/projects/go-tester/src/app/components/test-page-1/test-page-1.component.html
+++ b/projects/go-tester/src/app/components/test-page-1/test-page-1.component.html
@@ -1,6 +1,6 @@
 <div class="go-container">
-  <go-accordion [showIcons]="true" theme="dark" [slim]="true" class="go-column go-column--100">
-    <go-accordion-panel title="Test 1" icon="home" expanded="true">
+  <go-accordion [multiExpand]="true" [showIcons]="true" theme="dark" [slim]="true" class="go-column go-column--100">
+    <go-accordion-panel title="Test 1" icon="home" [expanded]="true">
       <p class="go-body-copy">This is some content for Test 1.</p>
     </go-accordion-panel>
     <go-accordion-panel title="Test 2" icon="settings">
@@ -12,7 +12,7 @@
   </go-accordion>
 
   <go-accordion [showIcons]="true" class="go-column go-column--100">
-    <go-accordion-panel title="Test 1" icon="home" expanded="true">
+    <go-accordion-panel title="Test 1" icon="home" [expanded]="true">
       <p class="go-body-copy">This is some content for Test 1.</p>
     </go-accordion-panel>
     <go-accordion-panel title="Test 2" theme="dark" icon="settings">
@@ -24,7 +24,7 @@
   </go-accordion>
 
   <go-accordion class="go-column go-column--100">
-    <go-accordion-panel heading="Test 1" expanded="true">
+    <go-accordion-panel heading="Test 1" [expanded]="true">
       <p class="go-body-copy">This is some content for Test 1.</p>
     </go-accordion-panel>
     <go-accordion-panel heading="Test 2">


### PR DESCRIPTION
This updates the accordion panel to use a simple object in the templates rather than functions. This forces us to manually update when the state changes but increases performance. 

Previous Angular was performing DOM manipulation changes when any event happened. Now it does not because it is more aware of when that happens.