### PR TITLE
Add grid modifiers for justify content

### DIFF
--- a/projects/go-lib/src/styles/_grid.scss
+++ b/projects/go-lib/src/styles/_grid.scss
@@ -1,4 +1,4 @@
-* { 
+* {
   box-sizing: border-box;
 }
 
@@ -17,14 +17,14 @@
   .go-column--#{$name} {
     flex-basis: percentage($size);
     width: percentage($size);
-    
+
     @if ($name <= 25) {
       @extend %tablet__flex-basis--50;
       @extend %mobile__flex-basis--100;
     } @else {
       @extend %tablet__flex-basis--100;
     }
-    
+
   }
 }
 
@@ -54,6 +54,22 @@
 
 .go-container--align-center {
   align-items: center;
+}
+
+.go-container--justify-center {
+  justify-content: center;
+}
+
+.go-container--justify-between {
+  justify-content: space-between;
+}
+
+.go-container--justify-end {
+  justify-content: flex-end;
+}
+
+.go-container--justify-start {
+  justify-content: flex-start;
 }
 
 .go-column--no-padding {


### PR DESCRIPTION
fixes #161 

This PR introduces a few more modifier classes for the grid system, allowing the user to control the spacing of items in a container using the [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) property.