### PR TITLE
Fix dark dropdown which was busted in Chrome on Windows

### DIFF
--- a/projects/go-lib/src/styles/_forms.scss
+++ b/projects/go-lib/src/styles/_forms.scss
@@ -128,6 +128,10 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   background-color: transparent;
   color: $theme-dark-color;
 
+  option {
+    color: black;
+  }
+
   &:disabled {
     background-color: $input--disabled-background;
     border-color:  $base-dark-secondary;


### PR DESCRIPTION
fixes #183 