### PR TITLE
[Bug] Table Page Item Count

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -34,4 +34,43 @@ describe('GoTableComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('outputResultsPerPage', () => {
+
+    beforeEach(() => {
+      component.localTableConfig.totalCount = 135;
+    });
+
+    it('calculates first number based on offset', () => {
+      component.localTableConfig.pageConfig.perPage = 50;
+      component.localTableConfig.pageConfig.offset = 10;
+
+      const resultSet: string = component.outputResultsPerPage();
+      const firstNumber: number = component.localTableConfig.pageConfig.offset + 1;
+      const secondNumber: number = component.localTableConfig.pageConfig.offset + component.localTableConfig.pageConfig.perPage;
+
+      expect(resultSet).toBe(firstNumber +  ' - ' + secondNumber);
+    });
+
+    it('calculates last number as totalCount if on last page', () => {
+      component.localTableConfig.pageConfig.perPage = 50;
+      component.localTableConfig.pageConfig.offset = 100;
+
+      const resultSet: string = component.outputResultsPerPage();
+      const firstNumber: number = component.localTableConfig.pageConfig.offset + 1;
+
+      expect(resultSet).toBe(firstNumber + ' - ' + component.localTableConfig.totalCount);
+    });
+
+    it('calculates last number as remainder of page if not on last page', () => {
+      component.localTableConfig.pageConfig.perPage = 50;
+      component.localTableConfig.pageConfig.offset = 50;
+
+      const resultSet: string = component.outputResultsPerPage();
+      const firstNumber: number = component.localTableConfig.pageConfig.offset + 1;
+      const secondNumber: number = component.localTableConfig.pageConfig.offset + component.localTableConfig.pageConfig.perPage;
+
+      expect(resultSet).toBe(firstNumber + ' - ' + secondNumber);
+    });
+  });
 });

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -188,7 +188,7 @@ export class GoTableComponent implements OnInit, OnChanges {
 
     const beginning: number = this.localTableConfig.pageConfig.offset + 1;
     const endingEstimate: number = pageConfig.offset + pageConfig.perPage;
-    const ending: number = endingEstimate <= totalCount ? endingEstimate : totalCount - pageConfig.offset;
+    const ending: number = endingEstimate <= totalCount ? endingEstimate : totalCount;
 
     return beginning + ' - ' + ending;
   }


### PR DESCRIPTION
## Issue
Fixes #188 

## Problem
Table page item count was incorrect when last page contained
a number of rows not equal to that of the page size

## Solution
Removed subtraction of pageCount from calculation logic