### PR TITLE
Fixes go select missing bind value

### DIFF
--- a/projects/go-lib/src/lib/components/go-select/go-select.component.html
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.html
@@ -8,7 +8,8 @@
 <ng-select
   [labelForId]="id"
   [items]="items"
-  bindLabel="{{bindLabel}}"
+  [bindLabel]="bindLabel"
+  [bindValue]="bindValue"
   [multiple]="multiple"
   [formControl]="control">
 </ng-select>

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -101,19 +101,21 @@
                 <go-select
                   [items]="selectData"
                   [control]="selectControl"
+                  bindValue="value"
                   bindLabel="name"
                   [hints]="['Select an option here, whatever you want']"
                   label="Select Box Here">
                 </go-select>
               </div>
               <div class="go-column go-column--50">
-                You selected: {{selectControl.value?.name}}
+                You selected value: {{selectControl.value}}
               </div>
 
               <div class="go-column go-column--50">
                 <go-select
                   [items]="selectData"
                   [control]="otherSelectControl"
+                  bindValue="value"
                   bindLabel="name"
                   [hints]="['This is disabled']"
                   label="Other Select Box">
@@ -124,6 +126,7 @@
                 <go-select
                   [items]="selectData"
                   [control]="validationSelectControl"
+                  bindValue="value"
                   bindLabel="name"
                   [hints]="['This is has a custom error message You need to select Ron.']"
                   label="Validated Select Box">
@@ -134,6 +137,7 @@
                 <go-select
                   [items]="selectData"
                   [control]="multiSelectControl"
+                  bindValue="value"
                   bindLabel="name"
                   multiple="true"
                   [hints]="['This is a multi select.']">

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
@@ -7,19 +7,19 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 })
 export class TestPage3Component {
   selectData: any = [{
-    id: 1,
+    value: 1,
     name: 'Harry'
   }, {
-    id: 2,
+    value: 2,
     name: 'Hermione'
   }, {
-    id: 3,
+    value: 3,
     name: 'Ron'
   }, {
-    id: 4,
+    value: 4,
     name: 'Voldermort'
   }, {
-    id: 5,
+    value: 5,
     name: 'Snake'
   }];
 


### PR DESCRIPTION
Our current implementation defaulted bindValue to be always an ID. Added the missing binding to the go select template so we can change it to whatever we want.