### PR TITLE
[Bug] Fixed Toast Heading Styles

### DIFF
--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -4,7 +4,7 @@
     <go-icon class="go-toast-status__icon" [ngClass]="statusClass" [icon]="icon"></go-icon>
   </div>
   <div class="go-toast-content"  [ngClass]="{ 'go-toast-content--no-title': !header }">
-    <h5 class="go-toast-content__title" *ngIf="header">{{ header }}</h5>
+    <h5 class="go-heading-5 go-toast-content__title" *ngIf="header">{{ header }}</h5>
     <p class="go-toast-content__message">{{ message }}</p>
   </div>
   <div class="go-toast-dismiss" *ngIf="dismissable">


### PR DESCRIPTION
## Problem
The heading element for toasts was not styled correctly. Closes #194 

## Solution
Applied the `go-heading-5` class to the heading element