### PR TITLE
[Bug] Side Nav Doesn't Scroll

### DIFF
--- a/projects/go-lib/src/lib/components/go-header/go-header.component.scss
+++ b/projects/go-lib/src/lib/components/go-header/go-header.component.scss
@@ -7,7 +7,7 @@ $breakpoint-header-mobile-small: 500px;
   background: $theme-light-bg;
   box-shadow: $global-box-shadow;
   display: flex;
-  height: 4rem;
+  height: $header-height;
   justify-content: space-between;
   position: relative;
   z-index: z-index(navigation);
@@ -65,7 +65,7 @@ $breakpoint-header-mobile-small: 500px;
   width: 15.5rem;
 
   @media (max-width: $breakpoint-mobile) {
-    height: 4rem;
+    height: $header-height;
   }
 }
 
@@ -84,7 +84,7 @@ $breakpoint-header-mobile-small: 500px;
 
   @media (max-width: $breakpoint-mobile) {
     flex: auto;
-    height: 4rem;
+    height: $header-height;
     order: 2;
     width: 100vw;
   }
@@ -105,7 +105,7 @@ $breakpoint-header-mobile-small: 500px;
 
   @media (max-width: $breakpoint-mobile) {
     flex: 1;
-    height: 4rem;
+    height: $header-height;
     justify-content: flex-end;
     padding: 0 1rem;
   }

--- a/projects/go-lib/src/lib/components/go-layout/go-layout.component.scss
+++ b/projects/go-lib/src/lib/components/go-layout/go-layout.component.scss
@@ -20,6 +20,7 @@ body {
 .go-layout__content {
   display: flex;
   flex-grow: 1;
+  height: calc(100vh - #{$header-height});
 }
 
 .go-layout__route-container {

--- a/projects/go-lib/src/styles/_variables.scss
+++ b/projects/go-lib/src/styles/_variables.scss
@@ -1,7 +1,3 @@
-// Structure
-$side-nav-width: 15.5rem;
-$side-nav-width--collapsed: 3.2rem;
-
 // UI Details
 // ----------------------------------------------------------------------------
 
@@ -25,7 +21,12 @@ $column-sizes: (
   66: 2 / 3,
   75: 3 / 4,
   100: 1
-);
+  );
+  
+$side-nav-width: 15.5rem;
+$side-nav-width--collapsed: 3.2rem;
+
+$header-height: 4rem;
 
 // Breakpoints
 $breakpoint-mobile: 768px;


### PR DESCRIPTION
## Problem
go-side-nav did not scroll vertically when the viewport was not tall enough to fit all of the navigation items. Closes #189 

## Solution
Set a height attribute on the container within the layout component.