### PR TITLE
[Chore] Adjust Menu Icon Size

### DIFF
--- a/projects/go-lib/src/lib/components/go-header/go-header.component.html
+++ b/projects/go-lib/src/lib/components/go-header/go-header.component.html
@@ -3,6 +3,7 @@
        [ngClass]="{ 'go-header__left--collapsed': isNavCollapsed() }">
     <go-icon-button class="go-header__menu"
              buttonIcon="menu"
+             buttonSize="medium"
              buttonTitle="Menu"
              (handleClick)="toggleSideMenu()">
     </go-icon-button>

--- a/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.html
+++ b/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.html
@@ -7,7 +7,7 @@
 >
   <go-icon
     [icon]="buttonIcon"
-    iconClass="go-icon--small"
+    [iconClass]="iconClass"
     class="go-icon-button__icon"
   ></go-icon>
 </button>

--- a/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.scss
@@ -17,7 +17,11 @@
     display: flex;
   }
 
-  &:hover, &:active, &:focus {
+  &:hover, &:focus {
     background: $theme-light-bg-hover;
+  }
+
+  &:active {
+    background: transparent;
   }
 }

--- a/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.ts
@@ -1,18 +1,32 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output
+} from '@angular/core';
 
 @Component({
   selector: 'go-icon-button',
   templateUrl: './go-icon-button.component.html',
   styleUrls: ['./go-icon-button.component.scss']
 })
-export class GoIconButtonComponent {
+export class GoIconButtonComponent implements OnChanges {
+
+  iconClass: string = '';
+
   @Input() buttonDisabled: boolean;
   @Input() buttonIcon: string;
+  @Input() buttonSize: string = 'small';
   @Input() buttonTitle: string;
 
-  @Output() handleClick = new EventEmitter();
+  @Output() handleClick: EventEmitter<void> = new EventEmitter();
 
-  public clicked(): void {
+  ngOnChanges(): void {
+    this.iconClass = 'go-icon--' + this.buttonSize;
+  }
+
+  clicked(): void {
     this.handleClick.emit();
   }
 }


### PR DESCRIPTION
## Problem
Menu Icon in the go-header was too small.

## Solution
Added the ability to specify a size on the go-icon-button which applies the corresponding styles to the go-icon child element. The new binding on the go-icon-button is `buttonSize`.
