### PR TITLE
[Bug] Remove BrowserModule + BrowerAnimationModule 

### DIFF
--- a/projects/go-lib/src/lib/components/go-layout/go-layout.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-layout/go-layout.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { GoLayoutComponent } from './go-layout.component';
@@ -19,6 +20,7 @@ describe('GoLayoutComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ GoLayoutComponent ],
       imports: [
+        BrowserAnimationsModule,
         GoLoaderModule,
         GoModalModule,
         GoOffCanvasModule,

--- a/projects/go-lib/src/lib/components/go-layout/go-layout.module.ts
+++ b/projects/go-lib/src/lib/components/go-layout/go-layout.module.ts
@@ -1,6 +1,4 @@
 import { NgModule } from '@angular/core';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
@@ -22,8 +20,6 @@ import { GoLayoutComponent } from './go-layout.component';
   ],
   imports: [
     // Angular
-    BrowserAnimationsModule,
-    BrowserModule,
     CommonModule,
     RouterModule,
     // Goponents

--- a/projects/go-lib/src/lib/components/go-loader/go-loader.module.ts
+++ b/projects/go-lib/src/lib/components/go-loader/go-loader.module.ts
@@ -1,4 +1,3 @@
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 
 import { GoIconModule } from '../go-icon/go-icon.module';
@@ -11,7 +10,6 @@ import { NgModule } from '@angular/core';
     GoLoaderComponent
   ],
   imports: [
-    BrowserAnimationsModule,
     CommonModule,
     GoIconModule
   ],

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.module.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.module.ts
@@ -1,10 +1,8 @@
-import { NgModule } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
-import { GoOffCanvasComponent } from "./go-off-canvas.component";
-import { GoOffCanvasDirective } from "./go-off-canvas.directive";
+import { GoOffCanvasComponent } from './go-off-canvas.component';
+import { GoOffCanvasDirective } from './go-off-canvas.directive';
 
 @NgModule({
   declarations: [
@@ -12,8 +10,6 @@ import { GoOffCanvasDirective } from "./go-off-canvas.directive";
     GoOffCanvasDirective
   ],
   imports: [
-    BrowserAnimationsModule,
-    BrowserModule,
     CommonModule
   ],
   exports: [

--- a/projects/go-lib/src/lib/components/go-search/go-search.module.ts
+++ b/projects/go-lib/src/lib/components/go-search/go-search.module.ts
@@ -1,8 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { GoIconModule } from '../go-icon/go-icon.module';
 import { GoLoaderModule } from '../go-loader/go-loader.module';
@@ -12,8 +10,6 @@ import { GoSearchComponent } from './go-search.component';
 @NgModule({
   declarations: [GoSearchComponent],
   imports: [
-    BrowserAnimationsModule,
-    BrowserModule,
     CommonModule,
     GoIconModule,
     GoLoaderModule,

--- a/projects/go-lib/src/lib/components/go-table/go-table.module.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.module.ts
@@ -1,7 +1,5 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { GoIconModule } from '../go-icon/go-icon.module';
 import { GoLoaderModule } from '../go-loader/go-loader.module';
@@ -15,8 +13,6 @@ import { GoTableComponent } from './go-table.component';
     GoTableComponent
   ],
   imports: [
-    BrowserAnimationsModule,
-    BrowserModule,
     CommonModule,
     GoIconModule,
     GoLoaderModule

--- a/projects/go-lib/src/lib/components/go-toaster/go-toaster.module.ts
+++ b/projects/go-lib/src/lib/components/go-toaster/go-toaster.module.ts
@@ -1,6 +1,4 @@
 import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 
 import { GoToasterService } from './go-toaster.service';
@@ -12,8 +10,6 @@ import { GoToastModule } from '../go-toast/go-toast.module';
     GoToasterComponent
   ],
   imports: [
-    BrowserAnimationsModule,
-    BrowserModule,
     CommonModule,
     GoToastModule
   ],


### PR DESCRIPTION
Remove BrowserModule + BrowerAnimationModule to address lazy loading issue stated in https://github.com/mobi/goponents/issues/195. This PR does introduce a **breaking change**.

@grahamhency TODO for documentation: State `BrowerAnimationModule` is a required import for animations to work (not sure what the process is for updating it).