### PR TITLE
Fix/side nav active route

### DIFF
--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.html
@@ -2,8 +2,7 @@
      [attr.title]="navItem.description">
   <a class="go-nav-item__link"
      [routerLinkActive]="['go-nav-item__link--active']"
-     [routerLink]="[navItem.route]"
-     [routerLinkActiveOptions]="{exact:true}">
+     [routerLink]="[navItem.route]">
     <go-icon [icon]="navItem.routeIcon"
              iconClass="go-nav-group__icon"
              *ngIf="navItem.routeIcon">


### PR DESCRIPTION
fixes #206 

This PR removes the "exact" config from the side nav's active router link config. This way all subroutes will still be considered active.