### PR TITLE
Table Column Sorting

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table-column.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table-column.component.ts
@@ -9,6 +9,7 @@ export class GoTableColumnComponent {
   @Input() field: string;
   @Input() title: string;
   @Input() width: number;
+  @Input() sortable?: boolean;
 
   @ContentChild('goTableCell') goTableCell: TemplateRef<any>;
   @ContentChild('goTableHead') goTableHead: TemplateRef<any>;

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.html
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.html
@@ -18,8 +18,8 @@
           </th>
           <th *ngFor="let col of columns"
               class="go-table__head-column"
-              (click)="col.sortable && toggleSort(col.field)"
-              [ngClass]="{'go-table__head--sortable': col.sortable}">
+              (click)="toggleSort(col.sortable, col.field)"
+              [ngClass]="{ 'go-table__head--sortable': col.sortable !== undefined ? col.sortable : localTableConfig.sortable }">
             <div class="go-table__head-content">
               <ng-container *ngIf="!col.goTableHead; else columnHeaderOutlet">
                 {{ col.title || col.field }}

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.html
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.html
@@ -10,7 +10,7 @@
            *ngIf="hasData(); else noDataTable">
       <thead class="go-table__head">
         <tr>
-          <th class="go-table__head-column"
+          <th class="go-table__head-column go-table__head--sortable"
               width="60"
               *ngIf="localTableConfig.selectable"
               (click)="toggleSelectAll()">
@@ -18,7 +18,8 @@
           </th>
           <th *ngFor="let col of columns"
               class="go-table__head-column"
-              (click)="toggleSort(col.field)">
+              (click)="col.sortable && toggleSort(col.field)"
+              [ngClass]="{'go-table__head--sortable': col.sortable}">
             <div class="go-table__head-content">
               <ng-container *ngIf="!col.goTableHead; else columnHeaderOutlet">
                 {{ col.title || col.field }}

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.scss
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.scss
@@ -60,7 +60,6 @@
   @include transition(background);
 
   color: $theme-light-color;
-  cursor: pointer;
   font-size: .75rem;
   font-weight: bold;
   letter-spacing: 1pt;
@@ -70,16 +69,20 @@
   text-transform: uppercase;
   white-space: nowrap;
 
-  &:hover {
-    background: $theme-light-app-bg;
-  }
-
   &:first-of-type {
     border-top-left-radius: $global-radius;
   }
 
   &:last-of-type {
     border-top-right-radius: $global-radius;
+  }
+}
+
+.go-table__head--sortable {
+  cursor: pointer;
+
+  &:hover {
+    background: $theme-light-app-bg;
   }
 }
 

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -9,6 +9,10 @@ import { GoTablePageConfig } from './go-table-paging.model';
 describe('GoTableComponent', () => {
   let component: GoTableComponent;
   let fixture: ComponentFixture<GoTableComponent>;
+  const tableConfig: GoTableConfig = new GoTableConfig({
+    pageable: true,
+    tableData: []
+  });
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -24,10 +28,8 @@ describe('GoTableComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GoTableComponent);
     component = fixture.componentInstance;
-    component.tableConfig = new GoTableConfig({
-      pageable: true,
-      tableData: []
-    });
+    component.tableConfig = tableConfig;
+
     fixture.detectChanges();
   });
 
@@ -71,6 +73,32 @@ describe('GoTableComponent', () => {
       const secondNumber: number = component.localTableConfig.pageConfig.offset + component.localTableConfig.pageConfig.perPage;
 
       expect(resultSet).toBe(firstNumber + ' - ' + secondNumber);
+    });
+  });
+
+  describe('toggleSort', () => {
+    beforeEach(() => {
+      spyOn(component.tableChange, 'emit');
+    });
+
+    afterEach(() => {
+      component.tableConfig = tableConfig;
+    });
+
+    it('should update columns if column is sortable', () => {
+      component.toggleSort(true, 'value');
+      expect(component.tableChange.emit).toHaveBeenCalled();
+    });
+
+    it('should not update columns if column is not sortable', () => {
+      component.toggleSort(false, 'value');
+      expect(component.tableChange.emit).not.toHaveBeenCalled();
+    });
+
+    it('should update columns if column sortable is undefined, but table is sortable', () => {
+      component.tableConfig.sortable = true;
+      component.toggleSort(undefined, 'value');
+      expect(component.tableChange.emit).toHaveBeenCalled();
     });
   });
 });

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterContentInit,
   Component,
   ContentChildren,
   ElementRef,
@@ -31,7 +32,7 @@ import { fadeTemplateAnimation } from '../../animations/fade.animation';
   templateUrl: './go-table.component.html',
   styleUrls: ['./go-table.component.scss']
 })
-export class GoTableComponent implements OnInit, OnChanges {
+export class GoTableComponent implements AfterContentInit, OnInit, OnChanges {
 
   @Input() loadingData: boolean = false;
   @Input() showTableActions: boolean = false;
@@ -71,6 +72,14 @@ export class GoTableComponent implements OnInit, OnChanges {
     this.renderTable();
   }
 
+  ngAfterContentInit(): void {
+    this.columns.forEach((column: GoTableColumnComponent) => {
+      if (column.sortable === undefined) {
+        column.sortable = this.localTableConfig.sortable;
+      }
+    });
+  }
+
   renderTable(): void {
     if (this.tableConfig) {
       this.localTableConfig = JSON.parse(JSON.stringify(this.tableConfig));
@@ -103,14 +112,13 @@ export class GoTableComponent implements OnInit, OnChanges {
   }
 
   toggleSort(columnField: string): void {
-    const { sortable, sortConfig, tableData }:
+    const { sortConfig, tableData }:
     {
-      sortable: boolean,
       sortConfig?: GoTableSortConfig,
       tableData: any[]
     } = this.localTableConfig;
 
-    if (tableData && sortable) {
+    if (tableData) {
       if (sortConfig && sortConfig.column === columnField) {
         this.localTableConfig.sortConfig.direction = this.toggleSortDir(sortConfig.direction);
       } else {

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterContentInit,
   Component,
   ContentChildren,
   ElementRef,
@@ -32,7 +31,7 @@ import { fadeTemplateAnimation } from '../../animations/fade.animation';
   templateUrl: './go-table.component.html',
   styleUrls: ['./go-table.component.scss']
 })
-export class GoTableComponent implements AfterContentInit, OnInit, OnChanges {
+export class GoTableComponent implements OnInit, OnChanges {
 
   @Input() loadingData: boolean = false;
   @Input() showTableActions: boolean = false;
@@ -72,14 +71,6 @@ export class GoTableComponent implements AfterContentInit, OnInit, OnChanges {
     this.renderTable();
   }
 
-  ngAfterContentInit(): void {
-    this.columns.forEach((column: GoTableColumnComponent) => {
-      if (column.sortable === undefined) {
-        column.sortable = this.localTableConfig.sortable;
-      }
-    });
-  }
-
   renderTable(): void {
     if (this.tableConfig) {
       this.localTableConfig = JSON.parse(JSON.stringify(this.tableConfig));
@@ -111,14 +102,17 @@ export class GoTableComponent implements AfterContentInit, OnInit, OnChanges {
     return this.hasData() && this.localTableConfig.pageable;
   }
 
-  toggleSort(columnField: string): void {
-    const { sortConfig, tableData }:
+  toggleSort(columnSortable: boolean, columnField: string): void {
+    const { sortable, sortConfig, tableData }:
     {
+      sortable: boolean,
       sortConfig?: GoTableSortConfig,
       tableData: any[]
     } = this.localTableConfig;
 
-    if (tableData) {
+    columnSortable = columnSortable !== undefined ? columnSortable : sortable;
+
+    if (tableData && columnSortable) {
       if (sortConfig && sortConfig.column === columnField) {
         this.localTableConfig.sortConfig.direction = this.toggleSortDir(sortConfig.direction);
       } else {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-sorting/table-sorting.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-sorting/table-sorting.component.html
@@ -64,4 +64,57 @@
       <go-table-column field="gender" title="Gender"></go-table-column>
       <go-table-column field="ip_address" title="IP Address"></go-table-column>
   </go-table>
+
+  <go-card class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h1 class="go-heading-5">Restricting by Column</h1>
+    </ng-container>
+    <ng-container go-card-content>
+      <p class="go-body-copy">
+        Sometimes we want a table to be sortable, but only want certain columns to be sortable. This can be done in one
+        of two ways. We can either make the table sortable by default and then disable sorting on certain columns, or we
+        can disable sorting by default on the table and enable it on a couple columns we want to be sortable.
+      </p>
+
+      <code [highlight]="tableSortConfig"></code>
+
+      <h2 class="go-heading-6">sortable</h2>
+      <p class="go-body-copy">
+        This property exists on <code class="code-block--inline">go-table-column</code> and can be used to turn sorting on or
+        off for a specific column.
+      </p>
+      <h2 class="go-heading-6">example.html</h2>
+      <code [highlight]="tableConfigRestrictColumn_html"></code>
+      <h2 class="go-heading-6">example.ts</h2>
+      <code [highlight]="tableConfigEx" class="code-block--no-bottom-margin"></code>
+    </ng-container>
+  </go-card>
+  <go-table class="go-column go-column--100" [tableConfig]="tableConfig" tableTitle="Restricting Sort By Column">
+    <go-table-column field="id" title="ID"></go-table-column>
+    <go-table-column field="name.first" title="First Name"></go-table-column>
+    <go-table-column field="name.last" title="Last Name"></go-table-column>
+    <go-table-column field="email" title="Email" [sortable]="false"></go-table-column>
+    <go-table-column field="gender" title="Gender" [sortable]="false"></go-table-column>
+    <go-table-column field="ip_address" title="IP Address" [sortable]="false"></go-table-column>
+  </go-table>
+
+  <go-card class="go-column go-column--100" id="restrictingSort">
+      <ng-container go-card-header>
+        <h1 class="go-heading-5">Enabling by Column</h1>
+      </ng-container>
+      <ng-container go-card-content>
+        <h2 class="go-heading-6">example.html</h2>
+        <code [highlight]="tableConfigEnableColumn_html"></code>
+        <h2 class="go-heading-6">example.ts</h2>
+        <code [highlight]="tableConfigEx_nosort" class="code-block--no-bottom-margin"></code>
+      </ng-container>
+    </go-card>
+    <go-table class="go-column go-column--100" [tableConfig]="tableConfig_nosort" tableTitle="Restricting Sort">
+      <go-table-column field="id" title="ID"></go-table-column>
+      <go-table-column field="name.first" title="First Name" [sortable]="true"></go-table-column>
+      <go-table-column field="name.last" title="Last Name" [sortable]="true"></go-table-column>
+      <go-table-column field="email" title="Email"></go-table-column>
+      <go-table-column field="gender" title="Gender"></go-table-column>
+      <go-table-column field="ip_address" title="IP Address"></go-table-column>
+    </go-table>
 </section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-sorting/table-sorting.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-sorting/table-sorting.component.ts
@@ -64,6 +64,28 @@ export class TableSortingComponent {
   });
   `;
 
+  tableConfigRestrictColumn_html: string = `
+  <go-table [tableConfig]="tableConfig">
+    <go-table-column field="id" title="ID"></go-table-column>
+    <go-table-column field="name.first" title="First Name"></go-table-column>
+    <go-table-column field="name.last" title="Last Name"></go-table-column>
+    <go-table-column field="email" title="Email" [sortable]="false"></go-table-column>
+    <go-table-column field="gender" title="Gender" [sortable]="false"></go-table-column>
+    <go-table-column field="ip_address" title="IP Address" [sortable]="false"></go-table-column>
+  </go-table>
+  `;
+
+  tableConfigEnableColumn_html: string = `
+  <go-table [tableConfig]="tableConfig">
+    <go-table-column field="id" title="ID"></go-table-column>
+    <go-table-column field="name.first" title="First Name" [sortable]="true"></go-table-column>
+    <go-table-column field="name.last" title="Last Name" [sortable]="true"></go-table-column>
+    <go-table-column field="email" title="Email"></go-table-column>
+    <go-table-column field="gender" title="Gender"></go-table-column>
+    <go-table-column field="ip_address" title="IP Address"></go-table-column>
+  </go-table>
+  `;
+
   tableConfig: GoTableConfig = new GoTableConfig({
     sortConfig: new GoTableSortConfig({
       column: 'name.first',

--- a/projects/go-tester/src/app/components/test-page-1/test-page-1.component.html
+++ b/projects/go-tester/src/app/components/test-page-1/test-page-1.component.html
@@ -49,9 +49,9 @@
       <go-button (handleClick)="showCurrentSelection()">Selection State</go-button>
     </ng-container>
     <go-table-column field="id" title="ID"></go-table-column>
-    <go-table-column field="name.first" title="First Name"></go-table-column>
-    <go-table-column field="name.last" title="Last Name"></go-table-column>
-    <go-table-column field="email" title="Email"></go-table-column>
+    <go-table-column field="name.first" [sortable]="true" title="First Name"></go-table-column>
+    <go-table-column field="name.last" [sortable]="true" title="Last Name"></go-table-column>
+    <go-table-column field="email" [sortable]="true" title="Email"></go-table-column>
     <go-table-column field="gender" title="Gender"></go-table-column>
     <go-table-column field="ip_address" title="IP Address"></go-table-column>
   </go-table>

--- a/projects/go-tester/src/app/components/test-page-1/test-page-1.component.ts
+++ b/projects/go-tester/src/app/components/test-page-1/test-page-1.component.ts
@@ -33,7 +33,8 @@ export class TestPage1Component implements OnInit {
         selectable: true,
         selectBy: 'id',
         tableData: data.results,
-        totalCount: data.totalCount
+        totalCount: data.totalCount,
+        sortable: false
       });
       this.tableLoading = false;
     });


### PR DESCRIPTION
closes #180 

Currently we have the ability to either have every column on a table sortable or none of them. There
are certain cases where we want to be able to just sort by a couple columns on a table. This provides a way for an implementor to decide which columns can be sortable on a table or which columns they want to not be sortable. If a column doesn't contain the sortable binding it will default to whatever is in the table config.