### PR TITLE
Use margin on toast item to accomplish padding between toasts

### DIFF
--- a/projects/go-lib/src/lib/components/go-toaster/go-toaster.component.scss
+++ b/projects/go-lib/src/lib/components/go-toaster/go-toaster.component.scss
@@ -4,7 +4,6 @@
 .go-toaster {
   bottom: 0;
   overflow: hidden;
-  padding: 1rem;
   position: fixed;
   right: 0;
   width: 400px;
@@ -18,5 +17,5 @@
 }
 
 .go-toaster__item {
-  padding-top: 1rem;
+  margin: 0 1rem 1rem 0;
 }


### PR DESCRIPTION
fixes #217 

This PR moves the padding styles from the toaster to the toast items, to avoid the z-index issues. Also I'm using margin instead of padding cuz just seemed more logical.