### PR TITLE
Switch toggle label position

### DIFF
--- a/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.html
+++ b/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.html
@@ -1,32 +1,36 @@
-<div class="go-form__switch-toggle__wrapper">
-  <div class="go-form__switch-toggle" (click)="toggle()">
-    <input 
-      [id]="id"
-      class="go-form__switch-toggle__input"
-      [ngClass]="{'go-form__input--error': control?.errors?.length && control.invalid, 'go-form__input--dark': theme === 'dark'}"
-      type="checkbox"
-      [formControl]="control"
-    >
-    <span class="go-form__switch-toggle__toggle"></span>
-  </div>
+<ng-container *ngTemplateOutlet="labelPosition === 'before' ? labelTemplate : null"></ng-container>
+<div class="go-form__switch-toggle" (click)="toggle()">
 
+  <input
+    [id]="id"
+    class="go-form__switch-toggle__input"
+    [ngClass]="{'go-form__input--error': control?.errors?.length && control.invalid, 'go-form__input--dark': theme === 'dark'}"
+    type="checkbox"
+    [formControl]="control"
+  >
+  <span class="go-form__switch-toggle__toggle"></span>
+</div>
+
+<ng-container *ngTemplateOutlet="labelPosition === 'after' ? labelTemplate : null"></ng-container>
+
+<go-hint *ngFor="let hint of hints" [message]="hint" [theme]="theme"></go-hint>
+
+<div *ngIf="control?.errors?.length">
+  <go-hint
+    *ngFor="let error of control.errors"
+    [message]="error.message"
+    [label]="error.type"
+    [theme]="theme"
+    type="negative"
+  ></go-hint>
+</div>
+
+<ng-template #labelTemplate>
   <label
     [attr.for]="id"
     class="go-form__label go-form__label--inline go-form__switch-toggle__label"
-    [ngClass]="{'go-form__label--dark': theme === 'dark'}"
+    [ngClass]="{'go-form__label--dark': theme === 'dark', 'go-form__switch-toggle__label--before': labelPosition === 'before'}"
   >
     {{ label }}
   </label>
-
-  <go-hint *ngFor="let hint of hints" [message]="hint" [theme]="theme"></go-hint>
-
-  <div *ngIf="control?.errors?.length">
-    <go-hint
-      *ngFor="let error of control.errors"
-      [message]="error.message"
-      [label]="error.type"
-      [theme]="theme"
-      type="negative"
-    ></go-hint>
-  </div>
-</div>
+</ng-template>

--- a/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.scss
+++ b/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.scss
@@ -61,14 +61,14 @@
   transform: translateX(1.125rem);
 }
 
-.go-form__switch-toggle__wrapper {
-  position: relative;
-}
-
 .go-form__switch-toggle__label {
   line-height: 1.125rem;
   padding-bottom: 0;
   padding-left: 0.75rem;
-  position: absolute;
   user-select: none;
+}
+
+.go-form__switch-toggle__label--before {
+  padding-left: 0;
+  padding-right: 0.75rem;
 }

--- a/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.ts
+++ b/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.ts
@@ -13,6 +13,7 @@ export class GoSwitchToggleComponent implements OnInit {
   @Input() key: string;
   @Input() hints: string[];
   @Input() label: string;
+  @Input() labelPosition: 'before' | 'after' = 'after';
   @Input() theme: 'light' | 'dark' = 'light';
 
   constructor() { }

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -149,8 +149,17 @@
               <div class="go-column go-column--100">
                 <go-switch-toggle
                   [control]="form.controls.toggle"
-                  label="Toggle Me"
+                  label="Toggle This"
                   [hints]="['please']"
+                ></go-switch-toggle>
+              </div>
+
+              <div class="go-column go-column--100">
+                <go-switch-toggle
+                  [control]="form.controls.toggle2"
+                  label="Toggle That"
+                  labelPosition="before"
+                  [hints]="['look, the label can go before the switch']"
                 ></go-switch-toggle>
               </div>
 

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
@@ -32,6 +32,7 @@ export class TestPage3Component implements OnInit {
     notes: new FormControl(''),
     radio: new FormControl({value: '', disabled: false}),
     toggle: new FormControl(false),
+    toggle2: new FormControl(false),
     date: new FormControl(new Date(2019, 4, 25)),
     date2: new FormControl('5/25/2019')
   });


### PR DESCRIPTION
fixes #233 

Following [material's slide-toggle](https://material.angular.io/components/slide-toggle/api), I named the binding `labelPosition` and set the options as `before` and `after`.