### PR TITLE
Add Placeholder Binding to GoSelect Component

### DIFF
--- a/projects/go-lib/src/lib/components/go-select/go-select.component.html
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.html
@@ -11,7 +11,8 @@
   [bindLabel]="bindLabel"
   [bindValue]="bindValue"
   [multiple]="multiple"
-  [formControl]="control">
+  [formControl]="control"
+  [placeholder]="placeholder">
 </ng-select>
 
 <go-hint *ngFor="let hint of hints" [message]="hint" [theme]="theme"></go-hint>

--- a/projects/go-lib/src/lib/components/go-select/go-select.component.ts
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.ts
@@ -18,6 +18,7 @@ export class GoSelectComponent implements OnInit {
   @Input() key: string;
   @Input() label: string;
   @Input() multiple: boolean = false;
+  @Input() placeholder: string;
   @Input() theme: 'light' | 'dark' = 'light';
 
   ngOnInit(): void {

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -104,6 +104,7 @@
                   bindValue="value"
                   bindLabel="name"
                   [hints]="['Select an option here, whatever you want']"
+                  placeholder="Select Box Placeholder"
                   label="Select Box Here">
                 </go-select>
               </div>


### PR DESCRIPTION
## Why do we need this?
Some implementations of select boxes require a placeholder to be designated for that select box. With our current version of the GoSelect component, we are not capable of adding a placeholder value.

## How does this solve that problem?
The NgSelect module allows us to pass it a placeholder for the select box. This adds the placeholder option as a binding to the GoSelect component and then leverages that binding when creating an NgSelect instance.

## Additional Information/Important Links
I leveraged the [HTML for Template/Header/Footer](https://github.com/ng-select/ng-select/blob/master/src/demo/app/examples/template-header-footer-example/template-header-footer-example.component.html) example that NgSelect provides in order to best implement this solution.