### PR TITLE
Add loading input to go-select

### DIFF
--- a/projects/go-lib/src/lib/components/go-select/go-select.component.html
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.html
@@ -10,6 +10,7 @@
   [items]="items"
   [bindLabel]="bindLabel"
   [bindValue]="bindValue"
+  [loading]="loading"
   [multiple]="multiple"
   [formControl]="control"
   [placeholder]="placeholder">

--- a/projects/go-lib/src/lib/components/go-select/go-select.component.ts
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.ts
@@ -17,6 +17,7 @@ export class GoSelectComponent implements OnInit {
   @Input() items: any[];
   @Input() key: string;
   @Input() label: string;
+  @Input() loading: boolean = false;
   @Input() multiple: boolean = false;
   @Input() placeholder: string;
   @Input() theme: 'light' | 'dark' = 'light';

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
@@ -176,7 +176,7 @@
       </div>
     </ng-container>
   </go-card>
-  <go-card id="form-select-errors" class="go-column go-column--100">
+  <go-card id="form-select-items" class="go-column go-column--100">
     <ng-container go-card-header>
       <h1 class="go-heading-5">Component Items</h1>
     </ng-container>
@@ -214,13 +214,13 @@
       </div>
     </ng-container>
   </go-card>
-  <go-card id="form-select-hints" class="go-column go-column--100">
+  <go-card id="form-select-multiple" class="go-column go-column--100">
     <ng-container go-card-header>
       <h1 class="go-heading-5">Component Multiple</h1>
     </ng-container>
     <ng-container go-card-content>
       <p class="go-body-copy">
-        Sometimes we may want to be able to select multiple things. We can achieve this throught the
+        Sometimes we may want to be able to select multiple things. We can achieve this through the
         <code class="code-block--inline">@Input() multiple: boolean = false;</code> binding. Setting <code class="code-block--inline">multiple</code>
         to true will turn the select into a multi select and will save an array of values instead of a single value.
       </p>
@@ -274,6 +274,44 @@
           <h2 class="go-heading-6 go-heading--underlined">Code</h2>
           <code
             [highlight]="select8Code"
+            class="code-block--no-bottom-margin"
+          ></code>
+        </div>
+      </div>
+    </ng-container>
+  </go-card>
+  <go-card id="form-select-loading" class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h1 class="go-heading-5">Component Loading</h1>
+    </ng-container>
+    <ng-container go-card-content>
+      <p class="go-body-copy">
+        Sometimes we may want to indicate that the items for our select have not yet been retrieved. We can achieve this through the 
+        <code class="code-block--inline">@Input() loading: boolean = false;</code> binding. Setting <code class="code-block--inline">loading</code>
+        to true will display a loading spinner within the select to indicate that the items are not yet available, 
+        while setting <code class="code-block--inline">loading</code> to false will remove the spinner and allow the select to function normally. 
+      </p>
+      <div class="go-container">
+        <div class="go-column go-column--50">
+          <h2 class="go-heading-6 go-heading--underlined">View</h2>
+          <go-select
+            bindLabel="name"
+            bindValue="value"
+            [control]="select9"
+            [items]="items"
+            [multiple]="true"
+            label="Favorite Candy"
+            [loading]="loadingSelectOptions"
+          ></go-select>
+        </div>
+        <div class="go-column go-column--50">
+          <h2 class="go-heading-6 go-heading--underlined">Code</h2>
+          <code
+            [highlight]="select9Code"
+            class="code-block--no-bottom-margin"
+          ></code>
+          <code
+            [highlight]="select9LoadingCode"
             class="code-block--no-bottom-margin"
           ></code>
         </div>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.ts
@@ -17,8 +17,11 @@ export class SelectDocsComponent implements OnInit {
   select6: FormControl = new FormControl('');
   select7: FormControl = new FormControl('');
   select8: FormControl = new FormControl('');
+  select9: FormControl = new FormControl('');
 
   hints: Array<string> = ['please select you favorite candy'];
+
+  loadingSelectOptions: boolean = true;
 
   select1Code: string = `
   <go-select
@@ -116,6 +119,22 @@ export class SelectDocsComponent implements OnInit {
     placeholder="Select a Candy"
     label="Favorite Candy"
   ></go-select>
+  `;
+
+  select9Code: string = `
+  <go-select
+    bindLabel="name"
+    bindValue="value"
+    [control]="select9"
+    [items]="items"
+    [multiple]="true"
+    label="Favorite Candy"
+    [loading]="loadingSelectOptions"
+  ></go-select>
+  `;
+
+  select9LoadingCode: string = `
+  loadingSelectOptions: boolean = true;
   `;
 
   ngOnInit(): void {

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -104,6 +104,7 @@
                   bindValue="value"
                   bindLabel="name"
                   [hints]="['Select an option here, whatever you want']"
+                  [loading]="loadingSelectOptions"
                   placeholder="Select Box Placeholder"
                   label="Select Box Here">
                 </go-select>

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
@@ -1,11 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: 'app-test-page-3',
   templateUrl: './test-page-3.component.html'
 })
-export class TestPage3Component {
+export class TestPage3Component implements OnInit {
   selectData: any = [{
     value: 1,
     name: 'Harry'
@@ -36,6 +36,7 @@ export class TestPage3Component {
     date2: new FormControl('5/25/2019')
   });
   loading: boolean = false;
+  loadingSelectOptions: boolean = true;
 
   otherThing: FormControl = new FormControl('test');
   testOtherThing: FormControl = new FormControl({ value: 'Disabled Input', disabled: true });
@@ -45,6 +46,12 @@ export class TestPage3Component {
   multiSelectControl: FormControl = new FormControl();
 
   constructor() { }
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.loadingSelectOptions = false;
+    }, 3000);
+  }
 
   onSubmit(): void {
     this.loading = true;


### PR DESCRIPTION
closes #255 

This adds a `loading` input to our `go-select` so that we can take advantage of `ng-select`'s loading spinner. This will allow us to indicate when the items which will populate a `go-select` dropdown are in the process of being retrieved.