### PR TITLE
Support HTML within toast message

### DIFF
--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -5,7 +5,7 @@
   </div>
   <div class="go-toast-content"  [ngClass]="{ 'go-toast-content--no-title': !header }">
     <h5 class="go-heading-5 go-toast-content__title" *ngIf="header">{{ header }}</h5>
-    <p class="go-toast-content__message">{{ message }}</p>
+    <p class="go-toast-content__message" [innerHTML]="message"></p>
   </div>
   <div class="go-toast-dismiss" *ngIf="dismissable">
     <button class="go-toast-dismiss__button" type="button">

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
@@ -30,7 +30,7 @@
 
       <h2 class="go-heading-6">message</h2>
       <p class="go-body-copy">
-        The text to be displayed as the message of the toast. This is optional, however either this binding or the
+        The text or non-executable HTML to be displayed as the message of the toast. This is optional, however either this binding or the
         <code class="code-block--inline">header</code> binding must be set.
       </p>
 
@@ -67,6 +67,8 @@
   <go-toast class="go-column go-column--100" header="Success!" message="The thing you did saved successfully." type="positive"></go-toast>
   <go-toast class="go-column go-column--100" header="Hey!" message="Did you know that this is pretty cool?"></go-toast>
   <go-toast class="go-column go-column--100" header="Oh No!" message="The thing you did didn't work right." type="negative"></go-toast>
+  <go-toast class="go-column go-column--100" header="HTML Example" type="positive"
+            message='&#x2192; <a href="https://github.com/mobi/goponents" target="_blank">#1 Design System</a> &#x2190;'></go-toast>
 
   <go-card class="go-column go-column--100">
     <ng-container go-card-header>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
@@ -24,6 +24,8 @@ export class ToastDocsComponent {
   <go-toast header="Success!" message="The thing you did saved successfully." type="positive"></go-toast>
   <go-toast header="Hey!" message="Did you know that this is pretty cool?"></go-toast>
   <go-toast header="Oh No!" message="The thing you did didn't work right." type="negative"></go-toast>
+  <go-toast header="HTML Example" type="positive"
+            message='&#x2192; <a href="https://github.com/mobi/goponents" target="_blank">#1 Design System</a> &#x2190;'></go-toast>
   `;
 
   dismiss_html: string = `

--- a/projects/go-tester/src/app/components/test-page-2/test-page-2.component.html
+++ b/projects/go-tester/src/app/components/test-page-2/test-page-2.component.html
@@ -89,5 +89,10 @@
               header="Announcement!"
               [dismissable]="true">
     </go-toast>
+    <go-toast type="positive"
+              header="HTML Example"
+              message='&#x2192; <a href="https://github.com/mobi/goponents" target="_blank">#1 Design System</a> &#x2190;'
+              [dismissable]="true">
+    </go-toast>
   </div>
 </div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Chore


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

HTML passed into `message` of toast would render as string instead of HTML.

Issue Number: https://github.com/mobi/goponents/issues/239


## What is the new behavior?

HTML passed into `message` of toast will render as HTML. Executable HTML is not supported!

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Closes: https://github.com/mobi/goponents/issues/239