### PR TITLE
Chore z index for load screen

### DIFF
--- a/projects/go-lib/src/lib/components/go-layout/go-layout.component.scss
+++ b/projects/go-lib/src/lib/components/go-layout/go-layout.component.scss
@@ -47,4 +47,5 @@ body {
   overflow: hidden;
   position: absolute;
   width: 100%;
+  z-index: z-index(loading-screen);
 }

--- a/projects/go-lib/src/styles/_mixins.scss
+++ b/projects/go-lib/src/styles/_mixins.scss
@@ -12,6 +12,7 @@ $z-index: (
   off-canvas: 300,
 	modal: 400,
   toaster: 500,
+  loading-screen: 600,
 );
 
 @function z-index($key) {


### PR DESCRIPTION
closes #269 

We need to add an additional option to our `$z-index` function that can be used for loading screens. The new value should be higher than all of the current options to ensure that nothing will appear on top of anything utilizing this option for its `z-index`.