### PR TITLE
[Chore] Loader Type Docs

### DIFF
--- a/projects/go-style-guide/src/app/features/ui-kit/components/loader-docs/loader-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/loader-docs/loader-docs.component.html
@@ -35,6 +35,8 @@
         <li><code class="code-block--inline">negative</code></li>
         <li><code class="code-block--inline">neutral</code></li>
         <li><code class="code-block--inline">positive</code></li>
+        <li><code class="code-block--inline">dark</code></li>
+        <li><code class="code-block--inline">light</code></li>
       </ol>
     </ng-container>
   </go-card>
@@ -53,6 +55,10 @@
           <go-loader loaderSize="small" loaderType="negative"></go-loader>
           <go-loader></go-loader>
           <go-loader loaderSize="large" loaderType="positive"></go-loader>
+          <go-loader loaderType="dark"></go-loader>
+          <div style="background:lightgrey; display:inline-block;">
+            <go-loader loaderSize="small" loaderType="light"></go-loader>
+          </div>
         </div>
       </div>
     </ng-container>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/loader-docs/loader-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/loader-docs/loader-docs.component.ts
@@ -19,6 +19,8 @@ export class LoaderDocsComponent {
   <go-loader loaderSize="small" loaderType="negative"></go-loader>
   <go-loader></go-loader>
   <go-loader loaderSize="large" loaderType="positive"></go-loader>
+  <go-loader loaderType="dark"></go-loader>
+  <go-loader loaderSize="small" loaderType="light"></go-loader>
   `;
 
   fadeHtml: string = `


### PR DESCRIPTION
## Problem
We were missing documentation around the dark and light loader options that were added.

## Solution
Added docs for them.

Closes #244 