### PR TITLE
Control state of per page dropdown from table config

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.html
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.html
@@ -59,7 +59,7 @@
   </div>
   <div class="go-table-toolbar" *ngIf="showPaging()">
     <div class="go-table-toolbar__page-size">
-      <select class="go-form__select go-table-toolbar__select" (change)="setPerPage($event)">
+      <select class="go-form__select go-table-toolbar__select" [value]="localTableConfig.pageConfig.perPage" (change)="setPerPage($event)">
         <option *ngFor="let size of localTableConfig.pageConfig.pageSizes"
                 [value]="[size]">{{ size }}</option>
       </select>


### PR DESCRIPTION
Sets the value of the dropdown based on `localTableConfig`

fixes #292 