### PR TITLE
Accordion Expression Changed After Checked

### DIFF
--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
@@ -1,10 +1,11 @@
 import {
+  ChangeDetectorRef,
   Component,
   EventEmitter,
   Input,
   OnChanges,
   OnInit,
-  Output,
+  Output
 } from '@angular/core';
 
 import { accordionAnimation } from '../../animations/accordion.animation';
@@ -48,6 +49,7 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
   @Output() toggle: EventEmitter<void> = new EventEmitter<void>();
 
   constructor(
+    private changeDetector: ChangeDetectorRef,
     private configService: GoConfigService
   ) { }
 
@@ -64,6 +66,10 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
 
   ngOnChanges(): void {
     this.updateClasses();
+  }
+
+  detectChanges(): void {
+    this.changeDetector.detectChanges();
   }
 
   updateClasses(): void {

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion.component.ts
@@ -37,6 +37,7 @@ export class GoAccordionComponent implements OnInit, AfterContentInit {
     this.panels.toArray().forEach((panel: GoAccordionPanelComponent, index: number) => {
       this.updatePanelState(panel, index);
       this.subscribePanel(panel);
+      panel.detectChanges();
     });
   }
   //#endregion


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Issue Number: https://github.com/mobi/goponents/issues/303

## What is the new behavior?
We're updating the accordion panel from the accordion after it's initialized. The problem with this is in production mode there isn't another lifecycle trigger after we change this and those changes won't get picked up by the browser. This can be fixed by manually triggering the change detection cycle after we update it so that the changes are picked up.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
