### PR TITLE
Add Page Numbers to Pagination

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table-page.model.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table-page.model.ts
@@ -1,0 +1,4 @@
+export interface GoTablePage {
+  number: number;
+  active: boolean;
+}

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.html
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.html
@@ -111,6 +111,13 @@
               type="button">
         <go-icon class="go-table-toolbar__page-controls-icon" icon="chevron_left"></go-icon>
       </button>
+      <button class="go-table-toolbar__page-numbers"
+              type="button"
+              *ngFor="let page of pages"
+              (click)="setPageByPageNumber(page.number)"
+              [ngClass]="{ 'go-table-toolbar__page-numbers--active': page.active }">
+        {{page.number}}
+      </button>
       <button (click)="nextPage()"
               [disabled]="isLastPage()"
               [ngClass]="{ 'go-table-toolbar__button--disabled': isLastPage() }"

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.scss
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.scss
@@ -234,3 +234,31 @@
 .go-table__icon-button-column {
   padding: .375rem 1.25rem;
 }
+
+.go-table-toolbar__page-numbers {
+  @include transition(background);
+
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  font-size: 0.875rem;
+  margin: 0 0.125rem .2rem .125rem;
+  padding: 0.25rem .5rem;
+  outline: none;
+  user-select: none;
+  line-height: 1rem;
+
+  &:active,
+  &:focus,
+  &:hover {
+    background: $theme-light-bg-hover;
+  }
+}
+
+.go-table-toolbar__page-numbers--active { 
+  background-color: $ui-color-positive;
+  color: $theme-dark-color;
+}

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.scss
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.scss
@@ -261,4 +261,8 @@
 .go-table-toolbar__page-numbers--active { 
   background-color: $ui-color-positive;
   color: $theme-dark-color;
+
+  &:hover {
+    background-color: $ui-color-positive-hover;
+  }
 }

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -114,4 +114,59 @@ describe('GoTableComponent', () => {
       expect(component.selectAllChecked).toBe(true);
     });
   });
+
+  describe('setPageByPageNumber', () => {
+    beforeEach(() => {
+      component.localTableConfig.totalCount = 135;
+      component.localTableConfig.pageConfig.perPage = 10;
+    });
+
+    it('should set page number numbers from 1-5 if 5 pages exist and on first page', () => {
+      component.setPageByPageNumber(1);
+      for (let i: number = 0; i < 5; i++) {
+        expect(component.pages[i].number).toBe(i + 1);
+      }
+    });
+
+    it('should set page number numbers from 1-5 if 5 pages exist and on second page', () => {
+      component.setPageByPageNumber(2);
+      for (let i: number = 0; i < 5; i++) {
+        expect(component.pages[i].number).toBe(i + 1);
+      }
+    });
+
+    it('should set page numbers around middle number if all pages exist', () => {
+      component.setPageByPageNumber(5);
+      for (let i: number = 0; i < 5; i++) {
+        // page numbers will be 3-7
+        expect(component.pages[i].number).toBe(i + 3);
+      }
+    });
+
+    it('should set page numbers to be the last 5 pages if on second to last page', () => {
+      component.setPageByPageNumber(13);
+      for (let i: number = 0; i < 5; i++) {
+        // page numbers will be 10-14
+        expect(component.pages[i].number).toBe(i + 10);
+      }
+    });
+
+    it('should set page numbers to be the last 5 pages if on last page', () => {
+      component.setPageByPageNumber(14);
+      for (let i: number = 0; i < 5; i++) {
+        // page numbers will be 10-14
+        expect(component.pages[i].number).toBe(i + 10);
+      }
+    });
+
+    it('should set page numbers to all pages if less than 5 pages exist', () => {
+      component.localTableConfig.totalCount = 37;
+      component.setPageByPageNumber(3);
+      for (let i: number = 0; i < 4; i++) {
+        // page numbers will be 1-4
+        expect(component.pages[i].number).toBe(i + 1);
+      }
+      expect(component.pages.length).toBe(4);
+    });
+  });
 });

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -29,6 +29,7 @@ import {
 import { sortBy } from './go-table-utils';
 import { fadeTemplateAnimation } from '../../animations/fade.animation';
 import { detailButtonAnim, tableRowBorderAnim } from '../../animations/table-details.animation';
+import { GoTablePage } from './go-table-page.model';
 
 @Component({
   animations: [
@@ -68,7 +69,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
   selectAllChecked: boolean = false;
   targetedRows: any[] = [];
   showTable: boolean = false;
-  pages: any[] = [];
+  pages: GoTablePage[] = [];
 
   constructor(private changeDetector: ChangeDetectorRef) { }
 
@@ -97,7 +98,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
 
       this.setTotalCount();
       this.handleSort();
-      this.setPage(0);
+      this.setPage();
     }
 
     this.showTable = Boolean(this.tableConfig);
@@ -140,7 +141,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
         this.localTableConfig.sortConfig = { column: columnField, direction: SortDirection.ascending };
       }
 
-      this.setPage(0);
+      this.setPage();
 
       this.tableChange.emit(this.localTableConfig);
       if (!this.isServerMode()) {
@@ -162,10 +163,6 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
       tableData: any[],
       totalCount: number
     } = this.localTableConfig;
-
-    if (offset === undefined) {
-      offset = pageConfig.offset;
-    }
 
     return ((offset + pageConfig.perPage) >= tableData.length) && ((offset + pageConfig.perPage) >= totalCount);
   }
@@ -194,14 +191,14 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   setFirstPage(): void {
-    this.setPage(0);
+    this.setPage();
 
     this.tableChangeOutcome();
   }
 
   setPerPage(event: any): void {
     this.localTableConfig.pageConfig.perPage = Number(event.target.value);
-    this.setPage(0);
+    this.setPage();
 
     this.tableChangeOutcome();
   }
@@ -359,7 +356,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
     return this.targetedRows.find((i: any) => i[this.localTableConfig.selectBy] === row[this.localTableConfig.selectBy]);
   }
 
-  private setPage(offset: number): void {
+  private setPage(offset: number = 0): void {
     const { pageConfig, totalCount }:
     {
       pageConfig: GoTablePageConfig,
@@ -373,14 +370,12 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
     this.pages = [];
 
     for (let i: number = startPage; i < startPage + 5; i++) {
-      if (i > lastPage) {
-        break;
-      } else {
-        this.pages.push({
-          number: i,
-          active: i === currentPage
-        });
-      }
+      if (i > lastPage) { break; }
+
+      this.pages.push({
+        number: i,
+        active: i === currentPage
+      });
     }
 
     this.localTableConfig.pageConfig.offset = offset;

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -68,6 +68,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
   selectAllChecked: boolean = false;
   targetedRows: any[] = [];
   showTable: boolean = false;
+  pages: any[] = [];
 
   constructor(private changeDetector: ChangeDetectorRef) { }
 
@@ -96,6 +97,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
 
       this.setTotalCount();
       this.handleSort();
+      this.setPage(0);
     }
 
     this.showTable = Boolean(this.tableConfig);
@@ -138,7 +140,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
         this.localTableConfig.sortConfig = { column: columnField, direction: SortDirection.ascending };
       }
 
-      this.localTableConfig.pageConfig.offset = 0;
+      this.setPage(0);
 
       this.tableChange.emit(this.localTableConfig);
       if (!this.isServerMode()) {
@@ -148,12 +150,12 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   nextPage(): void {
-    this.localTableConfig.pageConfig.offset = this.localTableConfig.pageConfig.offset + this.localTableConfig.pageConfig.perPage;
+    this.setPage(this.localTableConfig.pageConfig.offset + this.localTableConfig.pageConfig.perPage);
 
     this.tableChangeOutcome();
   }
 
-  isLastPage(): boolean {
+  isLastPage(offset: number): boolean {
     const { pageConfig, tableData, totalCount }:
     {
       pageConfig: GoTablePageConfig,
@@ -161,7 +163,11 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
       totalCount: number
     } = this.localTableConfig;
 
-    return ((pageConfig.offset + pageConfig.perPage) >= tableData.length) && ((pageConfig.offset + pageConfig.perPage) >= totalCount);
+    if (offset === undefined) {
+      offset = pageConfig.offset;
+    }
+
+    return ((offset + pageConfig.perPage) >= tableData.length) && ((offset + pageConfig.perPage) >= totalCount);
   }
 
   setLastPage(): void {
@@ -172,13 +178,13 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
     } = this.localTableConfig;
 
     const offset: number = totalCount - (totalCount % pageConfig.perPage);
-    this.localTableConfig.pageConfig.offset = offset === totalCount ? totalCount - pageConfig.perPage : offset;
+    this.setPage(offset === totalCount ? totalCount - pageConfig.perPage : offset);
 
     this.tableChangeOutcome();
   }
 
   prevPage(): void {
-    this.localTableConfig.pageConfig.offset = this.localTableConfig.pageConfig.offset - this.localTableConfig.pageConfig.perPage;
+    this.setPage(this.localTableConfig.pageConfig.offset - this.localTableConfig.pageConfig.perPage);
 
     this.tableChangeOutcome();
   }
@@ -188,14 +194,14 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   setFirstPage(): void {
-    this.localTableConfig.pageConfig.offset = 0;
+    this.setPage(0);
 
     this.tableChangeOutcome();
   }
 
   setPerPage(event: any): void {
     this.localTableConfig.pageConfig.perPage = Number(event.target.value);
-    this.localTableConfig.pageConfig.offset = 0;
+    this.setPage(0);
 
     this.tableChangeOutcome();
   }
@@ -299,6 +305,10 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
     row.showDetails = !row.showDetails;
   }
 
+  setPageByPageNumber(pageNumber: number): void {
+    this.setPage(this.localTableConfig.pageConfig.perPage * (pageNumber - 1));
+  }
+
   //#region Private Methods
   private handleSort(): void {
     const { sortConfig, sortable, tableData }:
@@ -347,6 +357,51 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
 
   private isRowInTargeted(row: any): boolean {
     return this.targetedRows.find((i: any) => i[this.localTableConfig.selectBy] === row[this.localTableConfig.selectBy]);
+  }
+
+  private setPage(offset: number): void {
+    const { pageConfig, totalCount }:
+    {
+      pageConfig: GoTablePageConfig,
+      totalCount: number
+    } = this.localTableConfig;
+
+    const lastPage: number = Math.ceil(totalCount / pageConfig.perPage);
+    const currentPage: number = (pageConfig.perPage + offset) / pageConfig.perPage;
+    const startPage: number = this.calculateStartPage(lastPage, currentPage);
+
+    this.pages = [];
+
+    for (let i: number = startPage; i < startPage + 5; i++) {
+      if (i > lastPage) {
+        break;
+      } else {
+        this.pages.push({
+          number: i,
+          active: i === currentPage
+        });
+      }
+    }
+
+    this.localTableConfig.pageConfig.offset = offset;
+  }
+
+  private calculateStartPage(lastPage: number, currentPage: number): number {
+    const pagesLeft: number = lastPage - currentPage;
+    let startPage: number = currentPage - 2;
+
+    if (startPage <= 1) {
+      startPage = 1;
+    }
+
+    if (lastPage - startPage < 4) {
+      startPage = currentPage - 4 + pagesLeft;
+      if (startPage < 1) {
+        startPage = 1;
+      }
+    }
+
+    return startPage;
   }
   //#endregion
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: https://github.com/mobi/goponents/issues/236


## What is the new behavior?
On the go-table if there is pagination there will be 5 pages that show up at a time in the page numbers. They will be centered around the active page unless that page is one of the first two pages or last two pages and then it will just have the first or last 5 pages showing.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

