### PR TITLE
Prevent Accordion Content from Initializing Before Opened

### DIFF
--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
@@ -33,7 +33,10 @@
       class="go-accordion-panel__content"
       [ngClass]="{'go-accordion-panel__content--slim': slim }"
     >
-      <ng-content></ng-content>
+      <ng-container *ngIf="loaded">
+        <ng-container *ngTemplateOutlet="panelContent"></ng-container>
+      </ng-container>
+      <ng-content *ngIf="!panelContent"></ng-content>
     </div>
   </div>
 </section>

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
@@ -33,7 +33,7 @@
       class="go-accordion-panel__content"
       [ngClass]="{'go-accordion-panel__content--slim': slim }"
     >
-      <ng-container *ngIf="loaded">
+      <ng-container *ngIf="panelContent && loaded">
         <ng-container *ngTemplateOutlet="panelContent"></ng-container>
       </ng-container>
       <ng-content *ngIf="!panelContent"></ng-content>

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.spec.ts
@@ -4,6 +4,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { GoAccordionPanelComponent } from './go-accordion-panel.component';
 import { GoIconModule } from '../go-icon/go-icon.module';
 import { GoConfigService } from '../../go-config.service';
+import { TemplateRef } from '@angular/core';
 
 describe('GoAccordionPanelComponent', () => {
   let component: GoAccordionPanelComponent;
@@ -75,6 +76,27 @@ describe('GoAccordionPanelComponent', () => {
 
       expect(component.containerClasses['go-accordion-panel--active']).toBe(true);
       expect(component.headerClasses['go-accordion-panel__header--active']).toBe(true);
+    });
+
+    it('sets loaded to true if expanded and using panelContent', () => {
+      component.expanded = true;
+
+      expect(component.loaded).toBe(true);
+    });
+
+    it('doesn\'t set loaded to false if already loaded and persistState is false', () => {
+      component.expanded = true;
+      component.expanded = false;
+
+      expect(component.loaded).toBe(true);
+    });
+
+    it('sets loaded to fales if already loaded and persistState is true', () => {
+      component.persistState = false;
+      component.expanded = true;
+      component.expanded = false;
+
+      expect(component.loaded).toBe(false);
     });
   });
 

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
@@ -6,7 +6,8 @@ import {
   Input,
   OnChanges,
   OnInit,
-  Output
+  Output,
+  TemplateRef
 } from '@angular/core';
 
 import { accordionAnimation } from '../../animations/accordion.animation';
@@ -45,7 +46,7 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
     this._expanded = expanded;
     this.containerClasses['go-accordion-panel--active'] = expanded;
     this.headerClasses['go-accordion-panel__header--active'] = expanded;
-    if (this.panelContent && expanded) {
+    if (expanded) {
       this.loaded = true;
     } else if (!this.persistState) {
       this.loaded = false;
@@ -57,7 +58,7 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
 
   @Output() toggle: EventEmitter<void> = new EventEmitter<void>();
 
-  @ContentChild('panelContent') panelContent: any;
+  @ContentChild('panelContent') panelContent: TemplateRef<any>;
 
   constructor(
     private changeDetector: ChangeDetectorRef,

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectorRef,
   Component,
+  ContentChild,
   EventEmitter,
   Input,
   OnChanges,
@@ -26,6 +27,7 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
   containerClasses: object = {};
   headerClasses: object = {};
   brandColor: string;
+  loaded: boolean = false;
 
   @Input() borderless: boolean;
   @Input() boxShadow: boolean;
@@ -42,12 +44,17 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
     this._expanded = expanded;
     this.containerClasses['go-accordion-panel--active'] = expanded;
     this.headerClasses['go-accordion-panel__header--active'] = expanded;
+    if (expanded) {
+      this.loaded = true;
+    }
   }
   get expanded(): boolean {
     return this._expanded;
   }
 
   @Output() toggle: EventEmitter<void> = new EventEmitter<void>();
+
+  @ContentChild('panelContent') panelContent: any;
 
   constructor(
     private changeDetector: ChangeDetectorRef,

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.ts
@@ -35,6 +35,7 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
   @Input() icon: string = null;
   @Input() isFirst: boolean = false;
   @Input() isLast: boolean = false;
+  @Input() persistState: boolean = true;
   @Input() slim: boolean;
   @Input() theme: 'dark' | 'light';
   @Input() title: string;
@@ -44,8 +45,10 @@ export class GoAccordionPanelComponent implements OnInit, OnChanges {
     this._expanded = expanded;
     this.containerClasses['go-accordion-panel--active'] = expanded;
     this.headerClasses['go-accordion-panel__header--active'] = expanded;
-    if (expanded) {
+    if (this.panelContent && expanded) {
       this.loaded = true;
+    } else if (!this.persistState) {
+      this.loaded = false;
     }
   }
   get expanded(): boolean {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
@@ -38,6 +38,14 @@
         The heading for the panel accepted as a string.
       </p>
 
+      <h2 class="go-heading-6">persistState</h2>
+      <p class="go-body-copy">
+        This is defaulted to true, but if set to false it will destroy any components inside of the 
+        panel when the panel is closed. This will cause any components inside to be recreated when the
+        accordion is opened every time. This is only useful if you are also using an ng-template to
+        not eager load the data inside the panel.
+      </p>
+
     </div>
   </go-card>
 
@@ -92,6 +100,53 @@
               This is a third thing. 
             </go-accordion-panel>
           </go-accordion>
+        </div>
+      </div>
+    </div>
+  </go-card>
+
+  <go-card class="go-column go-column--100">
+    <header go-card-header>
+      <h2 class="go-heading-5">Delayed Loading</h2>
+    </header>
+    <div go-card-content>
+      <div class="go-container">
+        <div class="go-column go-column--100">
+          The content inside of an accordion panel can be delayed in loading until a user expands the 
+          panel. This is useful when lots of data is being loaded inside of a child component inside 
+          of the panel. This can be done through using an ng-template to wrap the content inside the 
+          accordion panel.
+        </div>
+
+        <div class="go-column go-column--100">
+          <h2 class="go-heading-6">View</h2>
+          <go-accordion>
+            <go-accordion-panel heading="Not Delayed">
+              <app-loading-test></app-loading-test>
+            </go-accordion-panel>
+            <go-accordion-panel heading="Delay Loading">
+              <ng-template #panelContent>
+                <app-loading-test></app-loading-test>
+              </ng-template>
+            </go-accordion-panel>
+            <go-accordion-panel heading="Don't Persist State" [persistState]="false">
+              <ng-template #panelContent>
+                <app-loading-test></app-loading-test>
+              </ng-template>
+            </go-accordion-panel>
+          </go-accordion>
+        </div>
+        
+        <div class="go-column go-column--100">
+          <h2 class="go-heading-6">Code</h2>
+          <div class="go-container">
+            <div class="go-column go-column--50">
+              <code [highlight]="delayedLoadingExample"></code>
+            </div>
+            <div class="go-column go-column--50">
+              <code [highlight]="appLoadingTestExample"></code>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.ts
@@ -37,6 +37,36 @@ export class AccordionPanelDocsComponent {
   </go-accordion>
   `;
 
+  delayedLoadingExample: string = `
+  <go-accordion>
+    <go-accordion-panel heading="Not Delayed">
+      <app-loading-test></app-loading-test>
+    </go-accordion-panel>
+    <go-accordion-panel heading="Delay Loading">
+      <ng-template #panelContent>
+        <app-loading-test></app-loading-test>
+      </ng-template>
+    </go-accordion-panel>
+    <go-accordion-panel heading="Don't Persist State" [persistState]="false">
+      <ng-template #panelContent>
+        <app-loading-test></app-loading-test>
+      </ng-template>
+    </go-accordion-panel>
+  </go-accordion>
+  `;
+
+  appLoadingTestExample: string = `
+  @Component({
+    selector: 'app-loading-test',
+    template: ''
+  })
+  export class LoadingTestComponent {
+    constructor(private toasterService: GoToasterService) {
+      this.toasterService.toastSuccess({ message: 'Component loaded' });
+    }
+  }
+  `;
+
   componentBindings: string = `
   @Input() expanded:  boolean = false;
   @Input() icon:      string  = null;

--- a/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/loading-test.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/loading-test.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { GoToasterService } from 'projects/go-lib/src/public_api';
+
+@Component({
+  selector: 'app-loading-test',
+  template: ''
+})
+export class LoadingTestComponent {
+  constructor(private toasterService: GoToasterService) {
+    this.toasterService.toastSuccess({ message: 'Component loaded' });
+  }
+}

--- a/projects/go-style-guide/src/app/features/ui-kit/ui-kit.module.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/ui-kit.module.ts
@@ -87,6 +87,7 @@ import { AccordionOverviewComponent } from './components/accordion-docs/componen
 import { SwitchToggleDocsComponent } from './components/form-docs/components/switch-toggle-docs/switch-toggle-docs.component';
 import { RadioButtonDocsComponent } from './components/form-docs/components/radio-button-docs/radio-button-docs.component';
 import { CheckboxDocsComponent } from './components/form-docs/components/checkbox-docs/checkbox-docs.component';
+import { LoadingTestComponent } from './components/accordion-docs/components/accordion-panel-docs/loading-test.component';
 
 @NgModule({
   imports: [
@@ -164,7 +165,8 @@ import { CheckboxDocsComponent } from './components/form-docs/components/checkbo
     AccordionOverviewComponent,
     SwitchToggleDocsComponent,
     RadioButtonDocsComponent,
-    CheckboxDocsComponent
+    CheckboxDocsComponent,
+    LoadingTestComponent
   ],
   entryComponents: [
     BasicTestComponent,

--- a/projects/go-tester/src/app/components/off-canvas-test/off-canvas-test.component.html
+++ b/projects/go-tester/src/app/components/off-canvas-test/off-canvas-test.component.html
@@ -36,17 +36,19 @@
   </go-accordion>
 
   <go-accordion [showIcons]="true" class="go-column go-column--100">
-    <go-accordion-panel title="Test 1" icon="home" expanded="true">
-      <div class="go-column go-column--100">
-        <go-select
-          [items]="selectData"
-          [control]="selectControl"
-          bindValue="value"
-          bindLabel="name"
-          placeholder="Select Box Placeholder"
-          label="Select Box Here">
-        </go-select>
-      </div>
+    <go-accordion-panel title="Test 1" icon="home">
+      <ng-template #panelContent>
+        <div class="go-column go-column--100">
+          <go-select
+            [items]="selectData"
+            [control]="selectControl"
+            bindValue="value"
+            bindLabel="name"
+            placeholder="Select Box Placeholder"
+            label="Select Box Here">
+          </go-select>
+        </div>
+      </ng-template>
     </go-accordion-panel>
     <go-accordion-panel title="Test 2" icon="home" expanded="true">
       <p class="go-body-copy">This is some content for Test 2.</p>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Accordions will always load anything inside of it into the dom when it's loaded. This causes content that may never be rendered on the page to be loaded when the page is initialized, which is inefficient. Ideally we would be able to not load this content until the accordion is actually opened.


## What is the new behavior?
There is an option depending on how you initialize the accordion to not load the content of an accordion panel until it's clicked on. This is done through the use of ng-template and will require an extra line when writing the html for each accordion pane. 


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

There are no breaking changes, but going forward new accordion panels should probably be written with the ng-template instead of relying on ng-content because of the performance gains that this creates.
