### PR TITLE
Fix modal sizes and add additional documentation for modal sizes

### DIFF
--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.scss
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.scss
@@ -23,8 +23,8 @@
   box-shadow: $global-box-shadow--regular;
   color: $theme-light-color;
   max-height: 80%;
-  max-width: 50rem;
-  min-width: 31.25rem;
+  min-width: map-get($modal-container-sizes, 'lg');
+  max-width: map-get($modal-container-sizes, 'lg');
   padding: 1rem;
   position: relative;
   overflow-x: hidden;
@@ -36,7 +36,8 @@
 .go-modal__container-xl {
   @extend .go-modal__container;
 
-  min-width: 50rem;
+  min-width: map-get($modal-container-sizes, 'xl');
+  max-width: map-get($modal-container-sizes, 'xl');
 }
 
 .go-modal.go-modal--visible {

--- a/projects/go-lib/src/styles/_variables.scss
+++ b/projects/go-lib/src/styles/_variables.scss
@@ -32,6 +32,11 @@ $column-sizes: (
 $side-nav-width: 15.5rem;
 $side-nav-width--collapsed: 3.2rem;
 
+$modal-container-sizes: (
+  lg: 31.25rem,
+  xl: 50rem
+);
+
 $header-height: 4rem;
 
 // Breakpoints

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.html
@@ -1,18 +1,31 @@
 <header class="go-page-title">
-  <h1 class="go-heading-3">{{ pageTitle }}</h1>
+  <h1 class="go-heading-1">{{ pageTitle }}</h1>
 </header>
 
 <section class="go-container">
   <go-card [showHeader]="false" class="go-column go-column--100">
     <ng-container go-card-content>
       <!-- Intro -->
-      <h1 class="go-heading-5">Usage</h1>
+      <h3 class="go-heading-3">Usage</h3>
       <p class="go-body-copy">
         The <code class="code-block--inline">&lt;go-modal&gt;</code> component should be the only instance
         of a modal in the app.
       </p>
 
-      <h1 class="go-heading-5">Setup</h1>
+      <h3 class="go-heading-3">Bindings</h3>
+      <code [highlight]="componentBindings"></code>
+
+      <h4 class="go-heading-4">modalTitle</h4>
+      <p class="go-body-copy">
+        <code class="code-block--inline">modalTitle</code> sets the title for the modal.
+      </p>
+
+      <h4 class="go-heading-4">modalSize</h4>
+      <p class="go-body-copy">
+        <code class="code-block--inline">modalSize</code> defines the width of the modal. Currently defaulted to <code class="code-block--inline">lg</code>.
+      </p>
+
+      <h3 class="go-heading-3">Setup</h3>
       <p class="go-body-copy">To use the modal anywhere in the app, you must first add it to the app level. This should only be done once per application.</p>
       <ol style="list-style: numeric;">
         <li>
@@ -32,7 +45,7 @@
 
   <go-card class="go-column go-column--100">
     <ng-container go-card-header>
-      <h1 class="go-heading-5">Using the Modal service</h1>
+      <h3 class="go-heading-3">Using the Modal service</h3>
     </ng-container>
     <ng-container go-card-content>
       <div class="go-column go-column-100">
@@ -60,9 +73,7 @@
           <li>
             <p class="go-body-copy">
               To open the modal, use the service to call <code class="code-block--inline">openModal</code>. This method takes the component type
-              (ModalTestComponent in our case), and the bindings for that component as an object. There are two optional bindings <code class="code-block--inline">modalTitle</code>
-              (the title for modal) and <code class="code-block--inline">modalSize</code> which can be either <code class="code-block--inline">lg</code> or <code class="code-block--inline">xl</code>
-              (default <code class="code-block--inline">lg</code>).
+              (ModalTestComponent in our case), and the bindings for that component as an object.
             </p>
             <code [highlight]="ex_ModalDocsOpenModal"></code>
           </li>
@@ -72,11 +83,11 @@
             </p>
             <div class="go-container">
               <div class="go-column go-column--50">
-                <h2 class="go-heading-6">component.html</h2>
+                <h4 class="go-heading-4">component.html</h4>
                 <code [highlight]="ex_ModalDocsHtml"></code>
               </div>
               <div class="go-column go-column--50">
-                <h2 class="go-heading-6">View</h2>
+                <h4 class="go-heading-4">View</h4>
                 <go-button (handleClick)="openModal()">Click Me</go-button>
               </div>
             </div>
@@ -84,5 +95,32 @@
         </ol>
       </div>
     </ng-container>
+  </go-card>
+
+  <go-card class="go-column go-column--100">
+    <header go-card-header>
+      <h3 class="go-heading-3">Modal Sizes</h3>
+    </header>
+    <div go-card-content>
+      <div class="go-container">
+        <div class="go-column go-column--75">
+          <h4 class="go-heading-4">LG Code (Default)</h4>
+          <code [highlight]="ex_ModalDocsOpenLgModal"></code>
+        </div>
+        <div class="go-column go-column--25">
+          <h4 class="go-heading-4">LG View</h4>
+          <go-button (handleClick)="openLgModal()">Click Me</go-button>
+        </div>
+
+        <div class="go-column go-column--75">
+          <h4 class="go-heading-4">XL Code</h4>
+          <code [highlight]="ex_ModalDocsOpenXlModal"></code>
+        </div>
+        <div class="go-column go-column--25">
+          <h4 class="go-heading-4">XL View</h4>
+          <go-button (handleClick)="openXlModal()">Click Me</go-button>
+        </div>
+      </div>
+    </div>
   </go-card>
 </section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
@@ -13,8 +13,8 @@ export class ModalDocsComponent {
   pageTitle: string = 'Modal';
 
   componentBindings: string = `
-  @Input() modalTitle:  string      = '';
-  @Input() modalSize:   'lg' | 'xl' = 'lg';
+  @Input() modalTitle: string = '';
+  @Input() modalSize: 'lg' | 'xl' = 'lg';
   `;
 
   appModuleImport: string = `
@@ -73,7 +73,7 @@ export class ModalDocsComponent {
   ex_ModalDocsHtml: string = `<go-button (handleClick)="openModal()">Click Me</go-button>`;
 
   ex_ModalDocsOpenLgModal: string = `
-  this.goModalService.openModal(ModalTestComponent, { modalTitle: 'LG Modal (Default)', modalSize: 'lg', content: 'This is a lg modal' });
+  this.goModalService.openModal(ModalTestComponent, { modalTitle: 'LG Modal (Default)', content: 'This is a lg modal' });
   `;
 
   ex_ModalDocsOpenXlModal: string = `
@@ -87,7 +87,7 @@ export class ModalDocsComponent {
   }
 
   openLgModal(): void {
-    this.goModalService.openModal(ModalTestComponent, { modalTitle: 'LG Modal (Default)', modalSize: 'lg', content: 'This is a lg modal' });
+    this.goModalService.openModal(ModalTestComponent, { modalTitle: 'LG Modal (Default)', content: 'This is a lg modal' });
   }
 
   openXlModal(): void {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
@@ -12,6 +12,11 @@ export class ModalDocsComponent {
 
   pageTitle: string = 'Modal';
 
+  componentBindings: string = `
+  @Input() modalTitle:  string      = '';
+  @Input() modalSize:   'lg' | 'xl' = 'lg';
+  `;
+
   appModuleImport: string = `
   import { GoModalModule } from '@tangoe/goponents';
 
@@ -67,10 +72,26 @@ export class ModalDocsComponent {
 
   ex_ModalDocsHtml: string = `<go-button (handleClick)="openModal()">Click Me</go-button>`;
 
+  ex_ModalDocsOpenLgModal: string = `
+  this.goModalService.openModal(ModalTestComponent, { modalTitle: 'LG Modal (Default)', modalSize: 'lg', content: 'This is a lg modal' });
+  `;
+
+  ex_ModalDocsOpenXlModal: string = `
+  this.goModalService.openModal(ModalTestComponent, { modalTitle: 'XL Modal', modalSize: 'xl', content: 'This is a xl modal' });
+  `;
+
   constructor(private goModalService: GoModalService) { }
 
   openModal(): void {
     this.goModalService.openModal(ModalTestComponent, { modalTitle: 'Example Title', modalSize: 'xl', content: 'This is a modal!' });
+  }
+
+  openLgModal(): void {
+    this.goModalService.openModal(ModalTestComponent, { modalTitle: 'LG Modal (Default)', modalSize: 'lg', content: 'This is a lg modal' });
+  }
+
+  openXlModal(): void {
+    this.goModalService.openModal(ModalTestComponent, { modalTitle: 'XL Modal', modalSize: 'xl', content: 'This is a xl modal' });
   }
 
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/mobi/goponents/issues/313

An extension of changes made in PR https://github.com/mobi/goponents/pull/321


## What is the new behavior?

Currently `lg` always expands to the size of `xl` since the `max-width` was set equal to the size of `xl`. This is something I accidentally introduced in https://github.com/mobi/goponents/pull/321 😄 but luckily caught it before it was released. 

Also added additional documentation to showcase the different available sizes.  


## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A
