### PR TITLE
go-modal: Reset defaults on new component load

### DIFF
--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
@@ -36,7 +36,7 @@ describe('GoModalComponent', () => {
     goModalHostFixture = TestBed.createComponent(GoTestModalHostComponent);
 
     component = fixture.componentInstance;
-    component.goModalHost = goModalHostFixture.componentInstance.goModalHostRef;
+    component.goModalHost = goModalHostFixture.componentInstance.goModalHost;
 
     fixture.detectChanges();
   });
@@ -108,8 +108,4 @@ describe('GoModalComponent', () => {
 })
 class GoTestModalHostComponent {
   @ViewChild(GoModalDirective) goModalHost: GoModalDirective;
-
-  get goModalHostRef(): GoModalDirective {
-    return this.goModalHost;
-  }
 }

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
@@ -1,31 +1,115 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { Component, ViewChild } from '@angular/core';
 
-import { GoModalComponent } from './go-modal.component';
 import { GoIconModule } from '../go-icon/go-icon.module';
+import { GoModalComponent } from './go-modal.component';
+import { GoModalDirective } from './go-modal.directive';
+import { GoModalItem } from './go-modal.item';
 import { GoModalService } from './go-modal.service';
 
 describe('GoModalComponent', () => {
   let component: GoModalComponent;
   let fixture: ComponentFixture<GoModalComponent>;
+  let goModalHostFixture: ComponentFixture<GoTestModalHostComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        GoModalComponent
+        GoModalComponent,
+        GoTestModalHostComponent,
+        GoModalDirective
       ],
       imports: [ GoIconModule ],
       providers: [ GoModalService ]
+    })
+    .overrideModule(BrowserDynamicTestingModule, {
+      set: {
+        entryComponents: [ GoTestModalHostComponent ]
+      }
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(GoModalComponent);
+    goModalHostFixture = TestBed.createComponent(GoTestModalHostComponent);
+
     component = fixture.componentInstance;
+    component.goModalHost = goModalHostFixture.componentInstance.goModalHostRef;
+
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('loadComponent', () => {
+    beforeEach(() => {
+      spyOn(component.goModalHost.viewContainerRef, 'clear');
+
+      // Variables reset to initial component state
+      component.modalTitle = undefined;
+      component.modalSize = component.defaultModalSize;
+    });
+
+    afterEach(() => {
+      expect(component.goModalHost.viewContainerRef.clear).toHaveBeenCalled();
+    });
+
+    it('handles when no title and no modal size is set', () => {
+      component.currentComponent = new GoModalItem(GoTestModalHostComponent, {});
+
+      expect(component.modalTitle).toBeUndefined();
+      expect(component.modalSize).toEqual(component.defaultModalSize);
+
+      component.loadComponent();
+
+      expect(component.modalTitle).toEqual('');
+      expect(component.modalSize).toEqual(component.defaultModalSize);
+    });
+
+    it('handles when a title is set', () => {
+      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { modalTitle: 'Test Title' });
+
+      expect(component.modalTitle).toBeUndefined();
+
+      component.loadComponent();
+
+      expect(component.modalTitle).toEqual('Test Title');
+    });
+
+    it('handles when a modal size is set to supported size', () => {
+      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { modalSize: 'xl' });
+
+      expect(component.modalSize).toEqual(component.defaultModalSize);
+
+      component.loadComponent();
+
+      expect(component.modalSize).toEqual('xl');
+    });
+
+    it('handles when a modal size is set to unsupported size', () => {
+      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { modalSize: 'abc' });
+
+      expect(component.modalSize).toEqual(component.defaultModalSize);
+
+      component.loadComponent();
+
+      expect(component.modalSize).toEqual(component.defaultModalSize);
+    });
+  });
 });
+
+@Component({
+  selector: 'go-test',
+  template: '<ng-template go-modal-host></ng-template>'
+})
+class GoTestModalHostComponent {
+  @ViewChild(GoModalDirective) goModalHost: GoModalDirective;
+
+  get goModalHostRef(): GoModalDirective {
+    return this.goModalHost;
+  }
+}

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
@@ -9,10 +9,12 @@ import { GoModalService } from './go-modal.service';
   styleUrls: ['./go-modal.component.scss']
 })
 export class GoModalComponent implements OnInit {
+  readonly defaultModalSize: 'lg' | 'xl' = 'lg';
+
   currentComponent: any;
   opened: boolean = false;
   modalTitle: string;
-  modalSize: 'lg' | 'xl' = 'lg';
+  modalSize: 'lg' | 'xl' = this.defaultModalSize;
 
   @ViewChild(GoModalDirective) goModalHost: GoModalDirective;
   @ViewChild('goModalContainer') goModalContainer: any;
@@ -48,11 +50,15 @@ export class GoModalComponent implements OnInit {
     // Set title for modal if provided
     if (componentRef.instance['modalTitle']) {
       this.modalTitle = componentRef.instance['modalTitle'];
+    } else {
+      this.modalTitle = '';
     }
 
     // Set modal size if provided (by default set to 'lg')`
-    if (componentRef.instance['modalSize']) {
+    if (componentRef.instance['modalSize'] === 'lg' || componentRef.instance['modalSize'] === 'xl') {
       this.modalSize = componentRef.instance['modalSize'];
+    } else {
+      this.modalSize = this.defaultModalSize;
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Can't catch a break with this change 😅. Since `GoModalComponent` is being treated as a singleton via `GoModalService` - the values are persisting between different modals. For example if I execute

```
this.goModalService.openModal(ModalTestComponent, { modalTitle: 'XL Modal', modalSize: 'xl', content: 'This is a xl modal' });
```

and then execute

```
this.goModalService.openModal(ModalTestComponent, { content: 'This is a lg modal' });
```

One would expect the second modal to have a title of `''` and a size of `lg`. However, currently the second modal is persisting the values from first modal. 

Since this feature has not been released yet, I'm referencing the initial issue to add the feature.  

Issue Number: https://github.com/mobi/goponents/issues/313

An extension of changes made in PR's: https://github.com/mobi/goponents/pull/321, https://github.com/mobi/goponents/pull/333

## What is the new behavior?

title and size are reset to defaults per new component load

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A