### PR TITLE
Add Container Reset Class

### DIFF
--- a/projects/go-lib/src/styles/_grid.scss
+++ b/projects/go-lib/src/styles/_grid.scss
@@ -8,6 +8,10 @@
   margin: 0 (-$column-gutter);
 }
 
+.go-container--reset {
+  padding: 0 $column-gutter;
+}
+
 .go-column {
   flex: 1 1 auto;
   padding: 0 $column-gutter $column-gutter--double;

--- a/projects/go-style-guide/src/app/features/standards/components/grid/grid.component.html
+++ b/projects/go-style-guide/src/app/features/standards/components/grid/grid.component.html
@@ -230,24 +230,67 @@
 </section>
 
 <section id="align-center-container" class="go-container">
-    <go-card class="go-column">
-      <ng-container go-card-header>
-        <h2 class="go-heading-2">Center Alignment</h2>
-      </ng-container>
-      <ng-container go-card-content>
-        <p class="go-body-copy">
-          In some cases, it may be necessary to align items in a container vertically centered.
-          A modifier class can be added to acheive this:
-        </p>
-        <section class="go-container go-container--align-center example-grid">
-          <div class="go-column go-column--50 example-grid__column">
-            <p class="go-body-copy">Column 1, Row 1</p>
-            <p class="go-body-copy">Column 1, Row 2</p>
-            <p class="go-body-copy--no-margin">Column 1, Row 3</p>
-          </div>
-          <div class="go-column go-column--50 example-grid__column">Column 2</div>
-        </section>
-        <code [highlight]="alignCenterContainer"></code>
-      </ng-container>
-    </go-card>
-  </section>
+  <go-card class="go-column">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2">Center Alignment</h2>
+    </ng-container>
+    <ng-container go-card-content>
+      <p class="go-body-copy">
+        In some cases, it may be necessary to align items in a container vertically centered.
+        A modifier class can be added to acheive this:
+      </p>
+      <section class="go-container go-container--align-center example-grid">
+        <div class="go-column go-column--50 example-grid__column">
+          <p class="go-body-copy">Column 1, Row 1</p>
+          <p class="go-body-copy">Column 1, Row 2</p>
+          <p class="go-body-copy--no-margin">Column 1, Row 3</p>
+        </div>
+        <div class="go-column go-column--50 example-grid__column">Column 2</div>
+      </section>
+      <code [highlight]="alignCenterContainer"></code>
+    </ng-container>
+  </go-card>
+</section>
+
+<section id="container-reset" class="go-container">
+  <go-card class="go-column">
+    <ng-container go-card-header>
+      <h2 class="go-heading-4">Container Reset</h2>
+    </ng-container>
+    <ng-container go-card-content>
+      <h3 class="go-heading-5">Problem:</h3>
+      <p class="go-body-copy">
+        If we apply <code class="code-block--inline">.go-container</code> to an element whose parent 
+        does not provide any left or right padding, the negative margin of the 
+        <code class="code-block--inline">.go-container</code> will cause any .go-columns within it to 
+        lack the correct amount of left and right spacing. 
+      </p>
+      <p class="go-body-copy">
+        For example, if we are using a <code class="code-block--inline">.go-container</code> within a 
+        <code class="code-block--inline">.go-off-canvas</code>, since the <code class="code-block--inline">.go-off-canvas</code> 
+        itself does not apply and left or right padding, and since the negative margin of the 
+        <code class="code-block--inline">.go-container</code> will cancel out the left and right padding of any 
+        <code class="code-block--inline">.go-column</code> it contains, any <code class="code-block--inline">.go-column</code> 
+        within our <code class="code-block--inline">.go-container</code> will fail to have the proper left
+        and right spacing. 
+      </p>
+      <h3 class="go-heading-5">Solution:</h3>
+      <p class="go-body-copy">
+        We can solve this problem by also applying the <code class="code-block--inline">.go-container--reset</code> 
+        class to the element with the <code class="code-block--inline">.go-container</code> class, which will add left 
+        and right padding to offset the negative margin from <code class="code-block--inline">.go-container</code>, 
+        thus ensuring that any contained <code class="code-block--inline">.go-column</code> will have the correct 
+        left and right spacing.
+      </p>
+      <h3 class="go-heading-5">Example:</h3>
+      <go-button
+        (handleClick)="openOffCanvas()"
+        buttonIcon="subdirectory_arrow_right"
+        buttonVariant="neutral"
+      >
+        Open Off Canvas With Container Reset
+      </go-button>
+      <code [highlight]="containerReset"></code>
+    </ng-container>
+  </go-card>
+</section>

--- a/projects/go-style-guide/src/app/features/standards/components/grid/grid.component.html
+++ b/projects/go-style-guide/src/app/features/standards/components/grid/grid.component.html
@@ -255,10 +255,10 @@
 <section id="container-reset" class="go-container">
   <go-card class="go-column">
     <ng-container go-card-header>
-      <h2 class="go-heading-4">Container Reset</h2>
+      <h2 class="go-heading-2">Container Reset</h2>
     </ng-container>
     <ng-container go-card-content>
-      <h3 class="go-heading-5">Problem:</h3>
+      <h3 class="go-heading-3">Problem:</h3>
       <p class="go-body-copy">
         If we apply <code class="code-block--inline">.go-container</code> to an element whose parent 
         does not provide any left or right padding, the negative margin of the 
@@ -274,7 +274,7 @@
         within our <code class="code-block--inline">.go-container</code> will fail to have the proper left
         and right spacing. 
       </p>
-      <h3 class="go-heading-5">Solution:</h3>
+      <h3 class="go-heading-3">Solution:</h3>
       <p class="go-body-copy">
         We can solve this problem by also applying the <code class="code-block--inline">.go-container--reset</code> 
         class to the element with the <code class="code-block--inline">.go-container</code> class, which will add left 
@@ -282,12 +282,11 @@
         thus ensuring that any contained <code class="code-block--inline">.go-column</code> will have the correct 
         left and right spacing.
       </p>
-      <h3 class="go-heading-5">Example:</h3>
+      <h3 class="go-heading-3">Example:</h3>
       <go-button
         (handleClick)="openOffCanvas()"
         buttonIcon="subdirectory_arrow_right"
-        buttonVariant="neutral"
-      >
+        buttonVariant="neutral">
         Open Off Canvas With Container Reset
       </go-button>
       <code [highlight]="containerReset"></code>

--- a/projects/go-style-guide/src/app/features/standards/components/grid/grid.component.ts
+++ b/projects/go-style-guide/src/app/features/standards/components/grid/grid.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { GoOffCanvasService } from 'projects/go-lib/src/public_api';
+import { BasicTestComponent } from '../../../ui-kit/components/basic-test/basic-test.component';
 
 @Component({
   templateUrl: './grid.component.html',
@@ -92,4 +94,49 @@ export class GridComponent {
     <div class="go-column go-column--50">Column 2</div>
   </section>
   `;
+
+  containerReset: string = `
+  <form class="go-form go-form--dark">
+    <div class="go-container go-container--reset">
+      <div class="go-column go-column--50">
+        <label for="first-name-input" class="go-form__label">First Name</label>
+        <input class="go-form__input" id="first-name-input" placeholder="Jonny" type="text">
+      </div>
+      <div class="go-column go-column--50">
+        <label for="last-name-input" class="go-form__label">Last Name</label>
+        <input class="go-form__input" id="last-name-input" placeholder="Appleseed" type="text">
+      </div>
+      <div class="go-column go-column--100">
+        <label for="email-input" class="go-form__label">Email</label>
+        <input class="go-form__input" id="email-input" placeholder="your@email.com" type="email">
+      </div>
+      <div class="go-column go-column--100">
+        <label for="password-input" class="go-form__label">Password</label>
+        <input class="go-form__input" id="password-input" placeholder="**************" type="password">
+      </div>
+
+      <div class="go-column go-column--100">
+        <go-button
+          buttonVariant="positive"
+          (handleClick)="fakeSubmit()"
+          [useDarkTheme]="true"
+          #submitButton
+        >
+          Submit
+        </go-button>
+      </div>
+    </div>
+  </form>
+  `;
+
+  constructor(
+    private goOffCanvasService: GoOffCanvasService,
+  ) { }
+
+  openOffCanvas(): void {
+    this.goOffCanvasService.openOffCanvas({
+      component: BasicTestComponent,
+      bindings: {}
+    });
+  }
 }

--- a/projects/go-style-guide/src/app/features/standards/components/grid/grid.component.ts
+++ b/projects/go-style-guide/src/app/features/standards/components/grid/grid.component.ts
@@ -102,29 +102,7 @@ export class GridComponent {
         <label for="first-name-input" class="go-form__label">First Name</label>
         <input class="go-form__input" id="first-name-input" placeholder="Jonny" type="text">
       </div>
-      <div class="go-column go-column--50">
-        <label for="last-name-input" class="go-form__label">Last Name</label>
-        <input class="go-form__input" id="last-name-input" placeholder="Appleseed" type="text">
-      </div>
-      <div class="go-column go-column--100">
-        <label for="email-input" class="go-form__label">Email</label>
-        <input class="go-form__input" id="email-input" placeholder="your@email.com" type="email">
-      </div>
-      <div class="go-column go-column--100">
-        <label for="password-input" class="go-form__label">Password</label>
-        <input class="go-form__input" id="password-input" placeholder="**************" type="password">
-      </div>
-
-      <div class="go-column go-column--100">
-        <go-button
-          buttonVariant="positive"
-          (handleClick)="fakeSubmit()"
-          [useDarkTheme]="true"
-          #submitButton
-        >
-          Submit
-        </go-button>
-      </div>
+      <!-- ... -->
     </div>
   </form>
   `;

--- a/projects/go-style-guide/src/app/features/ui-kit/components/basic-test/basic-test.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/basic-test/basic-test.component.html
@@ -1,42 +1,42 @@
-<div class="basic-test">
-  <form class="go-form go-form--dark">
-    <div class="go-container">
-      <div class="go-column go-column--50">
-        <go-input
-          [control]="firstName"
-          key="first-name-input"
-          label="First Name"
-          placeholder="Jonny"
-        ></go-input>
-      </div>
-      <div class="go-column go-column--50">
-        <go-input
-          [control]="lastName"
-          key="last-name-input"
-          label="Last Name"
-          placeholder="Appleseed"
-        ></go-input>
-      </div>
-      <div class="go-column go-column--100">
-        <go-input
-          [control]="email"
-          inputType="email"
-          key="email-input"
-          label="Email"
-          placeholder="your@email.com"
-        ></go-input>
-      </div>
-      <div class="go-column go-column--100">
-        <go-input
-          [control]="password"
-          inputType="password"
-          key="password-input"
-          label="Password"
-          placeholder="**************"
-        ></go-input>
-      </div>
+<form class="go-form go-form--dark">
+  <div class="go-container go-container--reset">
+    <div class="go-column go-column--50">
+      <go-input
+        [control]="firstName"
+        key="first-name-input"
+        label="First Name"
+        placeholder="Jonny"
+      ></go-input>
     </div>
+    <div class="go-column go-column--50">
+      <go-input
+        [control]="lastName"
+        key="last-name-input"
+        label="Last Name"
+        placeholder="Appleseed"
+      ></go-input>
+    </div>
+    <div class="go-column go-column--100">
+      <go-input
+        [control]="email"
+        inputType="email"
+        key="email-input"
+        label="Email"
+        placeholder="your@email.com"
+      ></go-input>
+    </div>
+    <div class="go-column go-column--100">
+      <go-input
+        [control]="password"
+        inputType="password"
+        key="password-input"
+        label="Password"
+        placeholder="**************"
+      ></go-input>
+    </div>
+  </div>
 
+  <div class="go-column go-column--100">
     <go-button
       buttonVariant="positive"
       (handleClick)="fakeSubmit()"
@@ -45,5 +45,5 @@
     >
       Submit
     </go-button>
-  </form>
-</div>
+  </div>
+</form>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/basic-test/basic-test.component.scss
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/basic-test/basic-test.component.scss
@@ -1,5 +1,1 @@
-@import '../../../../../../../go-lib/src/styles/variables';
 
-.basic-test {
-  padding: $column-gutter--double $column-gutter $column-gutter;
-}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Our `.go-container` class provides negative left and right margin to avoid excessive left and right spacing from stacking up around elements with `.go-column`. This is needed because `.go-container` is generally used within elements that provide left and right spacing, and thus the left and right padding provided by `.go-column` would be added to that spacing in the absence of the negative margin provided by `.go-container`, which is not what we want.

The problem is that there are some cases in which we want to use `.go-container` within a context that does *not* provide any left and right spacing, and so the negative margin of `go-container` cancels out the left ad right padding of its `.go-column`s, eliminating the desired left and right spacing altogether.

Issue Number: #187

## What is the new behavior?
We can add a `.go-container--reset` utility class that adds left and right padding to offset the negative margin of `.go-container`, thus enabling the left and right padding of `.go-column` to apply the desired spacing.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
