### PR TITLE
Fix switch toggle label placement

### DIFF
--- a/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.html
+++ b/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.html
@@ -1,17 +1,19 @@
-<ng-container *ngTemplateOutlet="labelPosition === 'before' ? labelTemplate : null"></ng-container>
-<div class="go-form__switch-toggle" (click)="toggle()">
+<div class="go-form__switch-toggle__container">
+  <ng-container *ngTemplateOutlet="labelPosition === 'before' ? labelTemplate : null"></ng-container>
 
-  <input
-    [id]="id"
-    class="go-form__switch-toggle__input"
-    [ngClass]="{'go-form__input--error': control?.errors?.length && control.invalid, 'go-form__input--dark': theme === 'dark'}"
-    type="checkbox"
-    [formControl]="control"
-  >
-  <span class="go-form__switch-toggle__toggle"></span>
+  <div class="go-form__switch-toggle" (click)="toggle()">
+    <input
+      [id]="id"
+      class="go-form__switch-toggle__input"
+      [ngClass]="{'go-form__input--error': control?.errors?.length && control.invalid, 'go-form__input--dark': theme === 'dark'}"
+      type="checkbox"
+      [formControl]="control"
+    >
+    <span class="go-form__switch-toggle__toggle"></span>
+  </div>
+
+  <ng-container *ngTemplateOutlet="labelPosition === 'after' ? labelTemplate : null"></ng-container>
 </div>
-
-<ng-container *ngTemplateOutlet="labelPosition === 'after' ? labelTemplate : null"></ng-container>
 
 <go-hint *ngFor="let hint of hints" [message]="hint" [theme]="theme"></go-hint>
 

--- a/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.scss
+++ b/projects/go-lib/src/lib/components/go-switch-toggle/go-switch-toggle.component.scss
@@ -1,6 +1,10 @@
 @import '../../../styles/variables';
 @import '../../../styles/mixins';
 
+.go-form__switch-toggle__container {
+  display: flex;
+}
+
 .go-form__switch-toggle {
   display: inline-block;
   height: 1.125rem;
@@ -62,6 +66,7 @@
 }
 
 .go-form__switch-toggle__label {
+  flex: 1;
   line-height: 1.125rem;
   padding-bottom: 0;
   padding-left: 0.75rem;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
When the label text for a switch toggle is too long to fit within the width of its parent, it gets pushed down below the toggle.

Issue Number: #354 

## What is the new behavior?
With this PR, the label text is now positioned correctly regardless of its length.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

