### PR TITLE
Fix datepicker font-colors for dark theme

### DIFF
--- a/projects/go-lib/src/lib/components/go-datepicker/calendar-views.scss
+++ b/projects/go-lib/src/lib/components/go-datepicker/calendar-views.scss
@@ -1,6 +1,7 @@
 @import '../../../styles/variables';
 
 .go-calendar__header {
+  color: $theme-light-color;
   display: inline-flex;
   height: 1rem;
   margin-top: 0.5rem;
@@ -69,5 +70,6 @@
 }
 
 .go-calendar__table {
+  color: $theme-light-color;
   width: 100%;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Some of the font-colors for our go-datepicker inherit from their parent and thus are turned white when their parent uses our dark theme, making the font illegible on the white background of the datepicker.

![Screen Shot 2019-12-11 at 1 35 26 PM](https://user-images.githubusercontent.com/23343417/70651197-6528f100-1c1e-11ea-98ed-e9590d694773.png)

Issue Number: #363 

## What is the new behavior?
The font-colors of the datepicker are now set to black so that they are always visible on the white background of the datepicker.

![Screen Shot 2019-12-11 at 1 36 50 PM](https://user-images.githubusercontent.com/23343417/70651209-6823e180-1c1e-11ea-8408-db3d0044bae6.png)

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [ x] No
