### PR TITLE
Update Copy Button Styles

### DIFF
--- a/projects/go-lib/src/lib/components/go-copy/go-copy.component.html
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy.component.html
@@ -1,4 +1,4 @@
-<div class="go-copy" (click)="copyStringToClipboard()">
-  <go-icon icon="file_copy"></go-icon>
+<span class="go-copy" (click)="copyStringToClipboard()">
+  <go-icon icon="content_copy"></go-icon>
   <textarea class="go-copy__textarea" #copyText>{{text}}</textarea>
-</div>
+</span>

--- a/projects/go-lib/src/lib/components/go-copy/go-copy.component.scss
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy.component.scss
@@ -6,4 +6,5 @@
 .go-copy {
   overflow: hidden;
   position: relative;
+  cursor: pointer;
 }

--- a/projects/go-lib/src/lib/components/go-copy/go-copy.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy.component.spec.ts
@@ -57,7 +57,7 @@ describe('goCopyComponent', () => {
       fixture.detectChanges();
 
       const goCopyFixture: HTMLElement = fixture.nativeElement;
-      const copyElement: HTMLElement = goCopyFixture.querySelector('div');
+      const copyElement: HTMLElement = goCopyFixture.querySelector('span');
 
       // expectations for copyStringToClipboard method
       expect(copyElement.children[1].innerHTML).toEqual('test');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: css changes


## What is the current behavior?
When implementing a copy button inside of a column the icon will always be on the line after the content instead of beside it. The icon is also not clickable.

## What is the new behavior?
Make the element an inline element so that it won't appear on the next line. Make the copy icon appear clickable by making the cursor a pointer.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

