### PR TITLE
Add row input to text-area

### DIFF
--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.html
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.html
@@ -12,6 +12,7 @@
     [id]="id"
     [ngClass]="{'go-form__input--error': control?.errors?.length, 'go-form__input--dark': theme === 'dark'}"
     [placeholder]="placeholder"
+    [rows]="rows"
     [formControl]="control"
   ></textarea>
 

--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.ts
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.ts
@@ -14,6 +14,7 @@ export class GoTextAreaComponent implements OnInit {
   @Input() label: string;
   @Input() placeholder: string = '';
   @Input() theme: 'light' | 'dark' = 'light';
+  @Input() rows: number;
 
   constructor() { }
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/text-area-docs/text-area-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/text-area-docs/text-area-docs.component.html
@@ -300,4 +300,41 @@
 
     </div>
   </go-card>
+
+  <go-card id="form-textarea-placeholder" class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2">Component Rows</h2>
+    </ng-container>
+    <div class="go-container" go-card-content>
+
+      <div class="go-column go-column--100">
+        <p class="go-body-copy go-body-copy--no-margin">
+          The text area component's height can be set via
+          <code class="code-block--inline">@Input() rows: number;</code>
+          and the <code class="code-block--inline">[rows]</code> attribute.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <div class="go-container">
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">View</h4>
+            <go-text-area
+              [control]="message9"
+              label="Your Message"
+              rows="5"
+            ></go-text-area>
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+            <code
+              [highlight]="basicRowsExample"
+              class="code-block--no-bottom-margin"
+            ></code>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </go-card>
 </section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/text-area-docs/text-area-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/text-area-docs/text-area-docs.component.ts
@@ -14,6 +14,7 @@ export class TextAreaDocsComponent implements OnInit {
   message6: FormControl = new FormControl({ value: '', disabled: true });
   message7: FormControl = new FormControl('');
   message8: FormControl = new FormControl('');
+  message9: FormControl = new FormControl('');
 
   hints: Array<string> = [
     'Please type your message here',

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/text-area-docs/text-area-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/text-area-docs/text-area-docs.component.ts
@@ -97,6 +97,14 @@ export class TextAreaDocsComponent implements OnInit {
   ></go-text-area>
   `;
 
+  basicRowsExample: string = `
+  <go-text-area
+    [control]="message"
+    label="Your Message"
+    rows="5"
+  ></go-text-area>
+  `;
+
   constructor(private subNavService: SubNavService) {
     this.subNavService.pageTitle = 'Textarea';
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: chore


## What is the current behavior?
We currently have no means by which to modify the default height of a `go-text-area`.

Issue Number: #380 

## What is the new behavior?
We can now use the `rows` input to specify the default height of a `go-text-area`.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No
