### PR TITLE
Validates that year on datepicker is 4 or less digits

### DIFF
--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
@@ -156,6 +156,7 @@ describe('GoDatepickerComponent', () => {
     afterEach(() => {
       component.selectedDate = null;
       component.locale = null;
+      component.control.setValue(null);
     });
 
     it('should allow input based on locale', () => {
@@ -176,9 +177,20 @@ describe('GoDatepickerComponent', () => {
       expect(component.control.value).toEqual(new Date(2015, 11, 5));
     });
 
-    it('should set date to empty if invalid based on locale', () => {
+    it('should set date to null if invalid based on locale', () => {
       component.locale = 'de';
       component.selectedDate = '05.27.15';
+      component.control.setValue(new Date());
+
+      component.validateDate();
+
+      expect(component.control.value).toEqual(null);
+    });
+
+    it('should set date to null if year is more than 4 digits', () => {
+      component.locale = 'en-US';
+      component.selectedDate = '05/15/20121';
+      component.control.setValue(new Date());
 
       component.validateDate();
 

--- a/projects/go-lib/src/lib/components/go-datepicker/locale-format.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/locale-format.ts
@@ -35,7 +35,7 @@ export class LocaleFormat {
 
   static validDate(month: number, day: number, year: number): boolean {
     const validDays: Array<number> = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-    if (month > 12 || month < 1) {
+    if (year >= 10000 || month > 12 || month < 1) {
       return false;
     }
     if (day <= validDays[month - 1]) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: https://github.com/mobi/goponents/issues/382


## What is the new behavior?
A user can't type in a year that has more than 4 digits


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
