### PR TITLE
Add searchable input to go-select

### DIFF
--- a/projects/go-lib/src/lib/components/go-select/go-select.component.html
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.html
@@ -18,7 +18,8 @@
   [loading]="loading"
   [multiple]="multiple"
   [placeholder]="placeholder"
-  [typeahead]="typeahead">
+  [typeahead]="typeahead"
+  [searchable]="searchable">
   <ng-container *ngIf="multiple">
     <ng-template ng-header-tmp>
       <go-button buttonVariant="secondary" (handleClick)="onSelectAll()">Select All</go-button>

--- a/projects/go-lib/src/lib/components/go-select/go-select.component.ts
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.ts
@@ -27,6 +27,7 @@ export class GoSelectComponent implements OnInit {
   @Input() loading: boolean = false;
   @Input() multiple: boolean = false;
   @Input() placeholder: string;
+  @Input() searchable: boolean = true;
   @Input() typeahead?: Subject<string>;
   @Input() theme: 'light' | 'dark' = 'light';
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
@@ -351,10 +351,10 @@
 
       <div class="go-column go-column--100">
         <p class="go-body-copy go-body-copy--no-margin">
-          Sometimes we may want to indicate that the items for our select have not yet been retrieved. We can achieve this through the 
+          Sometimes we may want to indicate that the items for our select have not yet been retrieved. We can achieve this through the
           <code class="code-block--inline">@Input() loading: boolean = false;</code> binding. Setting <code class="code-block--inline">loading</code>
-          to true will display a loading spinner within the select to indicate that the items are not yet available, 
-          while setting <code class="code-block--inline">loading</code> to false will remove the spinner and allow the select to function normally. 
+          to true will display a loading spinner within the select to indicate that the items are not yet available,
+          while setting <code class="code-block--inline">loading</code> to false will remove the spinner and allow the select to function normally.
         </p>
       </div>
 
@@ -397,7 +397,7 @@
 
       <div class="go-column go-column--100">
         <p class="go-body-copy go-body-copy--no-margin">
-          The <code class="code-block--inline">@Input() appendTo: string;</code> binding is useful when implementing a 
+          The <code class="code-block--inline">@Input() appendTo: string;</code> binding is useful when implementing a
           <code class="code-block--inline">go-select</code> within a <code class="code-block--inline">go-modal</code>.
           Setting <code class="code-block--inline">appendTo</code> to <code class="code-block--inline">'body'</code> will prevent
           the modal from closing automatically upon selecting an item from the select dropdown.
@@ -423,7 +423,7 @@
     </div>
   </go-card>
 
-  <go-card id="form-select-loading" class="go-column go-column--100">
+  <go-card class="go-column go-column--100">
     <ng-container go-card-header>
       <h2 class="go-heading-2">Component Typeahead</h2>
     </ng-container>
@@ -468,6 +468,43 @@
     </div>
   </go-card>
 
+  <go-card class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2">Component Search</h2>
+    </ng-container>
+    <div class="go-container" go-card-content>
+
+      <div class="go-column go-column--100">
+        <p class="go-body-copy go-body-copy--no-margin">
+          By default, the component has search functionality, allowing for local typeahead on items already loaded into
+          the dropdown. The <code class="code-block--inline">@Input() searchable?: boolean;</code> binding
+          can be used to disable this feature, allowing the component to act as a regular dropdown.
+        </p>
+      </div>
+      <div class="go-column go-column--100 go-column--no-padding">
+        <div class="go-container">
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">View</h4>
+            <go-select
+              bindLabel="name"
+              bindValue="value"
+              [control]="select15"
+              [items]="items"
+              [searchable]="false"
+              label="Your Input"
+            ></go-select>
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+            <code
+              [highlight]="select15Code"
+              class="code-block--no-bottom-margin"
+            ></code>
+          </div>
+        </div>
+      </div>
+    </div>
+  </go-card>
   <go-card id="form-select-appendto" class="go-column go-column--100">
     <ng-container go-card-header>
       <h2 class="go-heading-2">Component groupBy</h2>
@@ -476,7 +513,7 @@
 
       <div class="go-column go-column--100">
         <p class="go-body-copy go-body-copy--no-margin">
-          The <code class="code-block--inline">@Input() groupBy: string;</code> binding is useful when implementing a 
+          The <code class="code-block--inline">@Input() groupBy: string;</code> binding is useful when implementing a
           <code class="code-block--inline">go-select</code> that has categories for the items being rendered in the dropdown.
           The value should be a string of the key to group by on each item.
         </p>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.ts
@@ -39,6 +39,7 @@ export class SelectDocsComponent implements OnInit {
   select12: FormControl = new FormControl('');
   select13: FormControl = new FormControl();
   select14: FormControl = new FormControl();
+  select15: FormControl = new FormControl('');
 
   hints: Array<string> = ['please select you favorite candy'];
 
@@ -265,6 +266,17 @@ export class SelectDocsComponent implements OnInit {
     { value: 1, name: 'Reeses' },
     { value: 2, name: 'Mints' }
   ];
+  `;
+
+  select15Code: string = `
+  <go-select
+    bindLabel="name"
+    bindValue="value"
+    [control]="select"
+    [items]="items"
+    [searchable]="false"
+    label="Your Input"
+  ></go-select>
   `;
 
   constructor(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
go-selects by default are "searchable", meaning they have a local typeahead feature. This PR exposed the `searchable` input from ng-select to control that behavior. 

Issue Number: #412 


## What is the new behavior?


## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
