### PR TITLE
Add Visual Disabled State to GoIconButton

### DIFF
--- a/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.html
+++ b/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.html
@@ -1,5 +1,6 @@
 <button
   class="go-icon-button"
+  [ngClass]="{ 'go-icon-button--disabled': buttonDisabled }"
   (click)="clicked()"
   [disabled]="buttonDisabled"
   [attr.title]="buttonTitle"

--- a/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-icon-button/go-icon-button.component.scss
@@ -25,3 +25,15 @@
     background: transparent;
   }
 }
+
+.go-icon-button--disabled {
+  color: lighten($theme-light-color, 40);
+  cursor: not-allowed;
+  pointer-events: none;
+
+  &:active,
+  &:focus,
+  &:hover {
+    background: none;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Chore


## What is the current behavior?

We currently can disable a `go-icon-button` with the `buttonDisabled` binding, but there is no visual change in the UI and it appears as though you can still click the button.

Issue Number: #376 

## What is the new behavior?

When `buttonDisabled` is true, the visual appearance of the `go-icon-button` changes so that it doesn't seem like you can click it.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No
