### PR TITLE
[Chore] Remove textarea from select docs

### DIFF
--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
@@ -44,11 +44,11 @@
       <div class="go-column go-column--100">
         <p class="go-body-copy go-body-copy--no-margin">
           All form components include an <code class="code-block--inline">@Input() label: string;</code>
-          that can be used to add a label to the textarea components.
+          that can be used to add a label to the select components.
           In addition to displaying an HTML label, the text passed
           in via the <code class="code-block--inline">[label]</code>
           attribute is used to generate a unique ID to associate the
-          label with the textarea. If no label is passed in, a generic,
+          label with the select. If no label is passed in, a generic,
           but still unique ID will be generated.
         </p>
       </div>
@@ -86,10 +86,10 @@
           As stated above the label attribute is used to generate a
           unique ID to associate the label with the select. As this might
           not be desired, the <code class="code-block--inline">@Input() key: string;</code>
-          can be used to configure the ID attribute of the textarea directly.
+          can be used to configure the ID attribute of the select directly.
           Anything passed into the component via the <code class="code-block--inline">[key]</code>
           attribute will be used to both assign the ID to the select and
-          associate the label with the textarea.
+          associate the label with the select.
         </p>
       </div>
 
@@ -115,7 +115,7 @@
             <p class="go-body-copy">
               Notice in the below example output that the <code class="code-block--inline">key</code> has been assigned
               to both the <code class="code-block--inline">id</code> attribute on
-              the textarea and the <code class="code-block--inline">for</code> attribute
+              the select and the <code class="code-block--inline">for</code> attribute
               on the label.
             </p>
             <code


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #432 


## What is the new behavior?
We now reference "select" in the places we were referencing "textarea"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
