### PR TITLE
[Bug] Accordion Panel Content Positioning

### DIFF
--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.html
@@ -21,9 +21,9 @@
       <span class="go-accordion-panel__title-text">{{ heading }}</span>
     </div>
     
-    <ng-container *ngIf="headerContent">
+    <div class="go-accordion-panel__projection">
       <ng-container *ngTemplateOutlet="headerContent"></ng-container>
-    </ng-container>
+    </div>
 
     <go-icon
       class="go-accordion-panel__control"

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
@@ -82,8 +82,12 @@
 .go-accordion-panel__title {
   align-items: center;
   display: flex;
-  flex-grow: 1;
   font-weight: 300;
+  padding-right: 1rem;
+}
+
+.go-accordion-panel__projection {
+  flex: 1;
 }
 
 .go-accordion-panel__title-icon {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
@@ -214,11 +214,7 @@
           </go-accordion-panel>
           <go-accordion-panel heading="Projected Heading">
             <ng-template #headerContent>
-              <div class="go-container go-container--justify-end">
-                <div class="go-column go-column--no-padding">
-                  <go-button>Projected</go-button>
-                </div>
-              </div>
+              <go-pill [removable]="false">Projected</go-pill>
             </ng-template>
           </go-accordion-panel>
         </go-accordion>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.ts
@@ -87,11 +87,7 @@ export class AccordionPanelDocsComponent {
     </go-accordion-panel>
     <go-accordion-panel heading="Projected Heading">
       <ng-template #headerContent>
-        <div class="go-container go-container--justify-end">
-          <div class="go-column go-column--no-padding">
-            <go-button>Projected</go-button>
-          </div>
-        </div>
+        <go-pill [removable]="false">Projected</go-pill>
       </ng-template>
     </go-accordion-panel>
   </go-accordion>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The `accordion-panel` has the ability to project content into the header. Currently, the content was being forced to the right every time.

## What is the new behavior?
The `accordion-panel` now projects content into the available space in the header

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
