### PR TITLE
[Bugfix] Modal Height Extends Beyond Page

### DIFF
--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.scss
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.scss
@@ -23,18 +23,20 @@
 }
 
 .go-modal__container {
+  @include transition(all);
+
   background: $theme-light-bg;
   border-radius: $global-radius;
   box-shadow: $global-box-shadow--regular;
   color: $theme-light-color;
-  min-width: map-get($modal-container-sizes, 'lg');
+  max-height: 100%;
   max-width: map-get($modal-container-sizes, 'lg');
-  padding: 1rem;
-  position: relative;
+  min-width: map-get($modal-container-sizes, 'lg');
   overflow-x: hidden;
   overflow-y: auto;
+  padding: 1rem;
+  position: relative;
   transform: scale(1.1);
-  @include transition(all);
 
   @media (max-width: $breakpoint-mobile) {
     max-width: 100%;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently the modal can extend beyond the edge of the page if there is too much content
Closes #476 

## What is the new behavior?
It stops at 100% of the available height and then scrolls

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
