### PR TITLE
[Bug] Table Search Subscription

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -910,14 +910,6 @@ describe('GoTableComponent', () => {
       }
     });
 
-    it('should render table if tableConfig exists', () => {
-      spyOn(component, 'renderTable');
-
-      component.ngOnInit();
-
-      expect(component.renderTable).toHaveBeenCalled();
-    });
-
     it('sets up a search term that filters table if config is set to searchable', fakeAsync(() => {
       component.tableConfig.searchConfig.searchable = true;
 
@@ -966,6 +958,7 @@ describe('GoTableComponent', () => {
       component.tableConfig.searchConfig.searchable = true;
       component.tableConfig.dataMode = GoTableDataSource.server;
 
+      component.renderTable();
       component.ngOnInit();
 
       component.searchTerm.setValue('koala bear');

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -81,7 +81,10 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
     if (!this.tableConfig) {
       throw new Error('GoTableComponent: tableConfig is a required Input');
     } else {
-      this.renderTable();
+      // we have to do call setupSearch here because it creates a subscription
+      // if we call it in ngOnChanges it will create a new subscription
+      // everytime ngOnChanges is triggered, which is not good
+      this.setupSearch();
     }
   }
 
@@ -103,7 +106,6 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
       this.allData = this.localTableConfig.tableData;
       this.setTotalCount();
       this.handleSort();
-      this.setupSearch();
       this.setPage(this.localTableConfig.pageConfig.offset);
     }
 
@@ -416,8 +418,9 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
       this.localTableConfig.searchConfig.searchTerm = searchTerm;
       if (!this.isServerMode()) {
         this.performSearch(searchTerm.toLowerCase());
+      } else {
+        this.tableChangeOutcome();
       }
-      this.tableChangeOutcome();
     });
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
~~Docs have been added / updated (for bug fixes / features)~~

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The `searchTerm` on the table search is being subscribed to on every `onChange` event. Causing an extreme amount of excess events to be called the more the table search is used.

## What is the new behavior?
Moved the `searchSetup` method into the `ngOnInit` instead of in `ngOnInit` so that we only subscribe to the changes once.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No