### PR TITLE
Go Select Select All Bind Value Errors

### DIFF
--- a/projects/go-lib/src/lib/components/go-select/go-select.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.spec.ts
@@ -77,10 +77,24 @@ describe('GoSelectComponent', () => {
 
   describe('onSelectAll()', () => {
     it('adds all of the available items to the form control value', () => {
+      component.bindValue = undefined;
       component.items = [
         { value: 1, label: 'Label 1' },
         { value: 2, label: 'Label 2' },
         { value: 3, label: 'Label 3' }
+      ];
+
+      component.onSelectAll();
+
+      expect(component.control.value).toEqual(component.items);
+    });
+
+    it('uses bindValue to get value if bindValue exists', () => {
+      component.bindValue = 'id';
+      component.items = [
+        { id: 1, label: 'Label 1' },
+        { id: 2, label: 'Label 2' },
+        { id: 3, label: 'Label 3' }
       ];
 
       component.onSelectAll();

--- a/projects/go-lib/src/lib/components/go-select/go-select.component.ts
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.ts
@@ -39,6 +39,6 @@ export class GoSelectComponent implements OnInit {
   }
 
   onSelectAll(): void {
-    this.control.patchValue(this.items.map((item: any) => item.value));
+    this.control.patchValue(this.items.map((item: any) => this.bindValue ? item[this.bindValue] : item));
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
~Docs have been added / updated (for bug fixes / features)~


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently if we are storing the value of the item in the go select on a key other then value and select all is clicked there are empty values attached to the go-select instead of grabbing the values based on the key that bindValue maps to.


## What is the new behavior?
If there is a bindValue that is passed in, we use that as the key to get the value of the item, otherwise we select the entire object, which is the default that ng-select uses.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
