### PR TITLE
[Chore] Add ability to hide the "select all" button on multiple select

### DIFF
--- a/projects/go-lib/src/lib/components/go-select/go-select.component.html
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.html
@@ -21,7 +21,7 @@
   [placeholder]="placeholder"
   [typeahead]="typeahead"
   [searchable]="searchable">
-  <ng-container *ngIf="multiple">
+  <ng-container *ngIf="multiple && showSelectAll">
     <ng-template ng-header-tmp>
       <go-button buttonVariant="secondary" (handleClick)="onSelectAll()">Select All</go-button>
     </ng-template>

--- a/projects/go-lib/src/lib/components/go-select/go-select.component.ts
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.ts
@@ -29,6 +29,7 @@ export class GoSelectComponent implements OnInit {
   @Input() multiple: boolean = false;
   @Input() placeholder: string;
   @Input() searchable: boolean = true;
+  @Input() showSelectAll: boolean = true;
   @Input() typeahead?: Subject<string>;
   @Input() theme: 'light' | 'dark' = 'light';
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
@@ -275,7 +275,7 @@
         </p>
       </div>
 
-      <div class="go-column go-column--100 go-column--no-padding">
+      <div class="go-column go-column--100">
         <div class="go-container">
           <div class="go-column go-column--50">
             <h4 class="go-heading-4 go-heading--underlined">View</h4>
@@ -292,6 +292,34 @@
             <h4 class="go-heading-4 go-heading--underlined">Code</h4>
             <code
               [highlight]="select7Code"
+              class="code-block--no-bottom-margin"
+            ></code>
+          </div>
+        </div>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <div class="go-container">
+          <div class="go-column go-column--100">
+            If need be, you can also remove the "Select All" button using the
+            <code class="code-block--inline">@Input() showSelecAll: boolean = false;</code> binding.
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">View</h4>
+            <go-select
+              bindLabel="name"
+              bindValue="value"
+              [control]="select7"
+              [items]="items"
+              [multiple]="true"
+              [showSelectAll]="false"
+              label="Favorite Candy"
+            ></go-select>
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+            <code
+              [highlight]="select7Code_noSelectAll"
               class="code-block--no-bottom-margin"
             ></code>
           </div>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { GoModalService, GoSelectComponent } from 'projects/go-lib/src/public_api';
-import { SubNavService } from 'projects/go-style-guide/src/app/shared/components/sub-nav/sub-nav.service';
+import { GoModalService, GoSelectComponent } from '../../../../../../../../../go-lib/src/public_api';
+import { SubNavService } from '../../../../../../shared/components/sub-nav/sub-nav.service';
 import { debounceTime, map } from 'rxjs/operators';
 import { concat, of, Subject } from 'rxjs';
 
@@ -128,6 +128,20 @@ export class SelectDocsComponent implements OnInit {
     [control]="select"
     [items]="items"
     [multiple]="true"
+    label="Favorite Candy">
+  </go-select>
+  `;
+
+  select7Code_noSelectAll: string = `
+  <!-- add: [showSelectAll]="false" -->
+
+  <go-select
+    bindLabel="name"
+    bindValue="value"
+    [control]="select"
+    [items]="items"
+    [multiple]="true"
+    [showSelectAll]="false"
     label="Favorite Candy">
   </go-select>
   `;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The "Select All" button always shows up when the `go-select` has the `[multiple]="true"` binding.
Closes #495 

## What is the new behavior?
There is a new binding `[showSelectAll]` that can be passed in that will hide the "Select All" button.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
