### PR TITLE
[Chore] Add ability to remove modal content padding

### DIFF
--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.html
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.html
@@ -1,12 +1,24 @@
-<div class="go-modal" [ngClass]="goModalClasses()" (click)="backdropClick($event)" #goModal>
-  <div [ngClass]="{'go-modal__container': modalSize === 'lg', 'go-modal__container-xl': modalSize === 'xl'}">
+<div
+  class="go-modal"
+  [ngClass]="goModalClasses()"
+  (click)="backdropClick($event)"
+  #goModal>
+  <div
+    class="go-modal__container"
+    [ngClass]="{'go-modal__container--lg': modalSize === 'lg', 'go-modal__container--xl': modalSize === 'xl'}">
     <div class="go-modal__header">
       <h3 class="go-heading-3">{{ modalTitle }}</h3>
-      <div class="go-modal__close" (click)="closeModal()">
-        <go-icon icon="close"></go-icon>
-      </div>
+      <go-icon-button
+        buttonIcon="close"
+        class="go-modal__close"
+        (handleClick)="closeModal()">
+      </go-icon-button>
     </div>
-    <ng-template go-modal-host>
-    </ng-template>
+    <div
+      class="go-modal__content"
+      [ngClass]="{ 'go-modal__content--no-padding': noContentPadding }">
+      <ng-template go-modal-host>
+      </ng-template>
+    </div>
   </div>
 </div>

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.scss
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.scss
@@ -30,13 +30,15 @@
   box-shadow: $global-box-shadow--regular;
   color: $theme-light-color;
   max-height: 100%;
-  max-width: map-get($modal-container-sizes, 'lg');
-  min-width: map-get($modal-container-sizes, 'lg');
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 1rem;
   position: relative;
   transform: scale(1.1);
+}
+
+.go-modal__container--lg {
+  max-width: map-get($modal-container-sizes, 'lg');
+  min-width: map-get($modal-container-sizes, 'lg');
 
   @media (max-width: $breakpoint-mobile) {
     max-width: 100%;
@@ -44,9 +46,7 @@
   }
 }
 
-.go-modal__container-xl {
-  @extend .go-modal__container;
-
+.go-modal__container--xl {
   min-width: map-get($modal-container-sizes, 'xl');
   max-width: map-get($modal-container-sizes, 'xl');
 
@@ -66,9 +66,10 @@
 }
 
 .go-modal__header {
-  display: flex;
   align-items: flex-start;
+  display: flex;
   justify-content: space-between;
+  padding: 1rem 1rem 0;
 }
 
 .go-modal__close {
@@ -76,4 +77,12 @@
   cursor: pointer;
   font-size: 1.25rem;
   margin-left: .5rem;
+}
+
+.go-modal__content {
+  padding: 0 1rem 1rem;
+}
+
+.go-modal__content--no-padding {
+  padding: 0;
 }

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { Component, ViewChild } from '@angular/core';
 
-import { GoIconModule } from '../go-icon/go-icon.module';
+import { GoIconButtonModule } from '../go-icon-button/go-icon-button.module';
 import { GoModalComponent } from './go-modal.component';
 import { GoModalDirective } from './go-modal.directive';
 import { GoModalItem } from './go-modal.item';
@@ -20,7 +20,7 @@ describe('GoModalComponent', () => {
         GoTestModalHostComponent,
         GoModalDirective
       ],
-      imports: [ GoIconModule ],
+      imports: [ GoIconButtonModule ],
       providers: [ GoModalService ]
     })
     .overrideModule(BrowserDynamicTestingModule, {

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
@@ -21,9 +21,10 @@ export class GoModalComponent implements OnInit {
   readonly defaultModalSize: 'lg' | 'xl' = 'lg';
 
   currentComponent: any;
-  opened: boolean = false;
   modalTitle: string;
   modalSize: 'lg' | 'xl' = this.defaultModalSize;
+  noContentPadding: boolean = false;
+  opened: boolean = false;
 
   @ViewChild(GoModalDirective) goModalHost: GoModalDirective;
   @ViewChild('goModal') goModal: ElementRef<HTMLElement>;
@@ -34,13 +35,13 @@ export class GoModalComponent implements OnInit {
   ) {
   }
 
-  ngOnInit() {
-    this.goModalService.activeModalComponent.subscribe((value) => {
+  ngOnInit(): void {
+    this.goModalService.activeModalComponent.subscribe((value: any) => {
       this.currentComponent = value;
       this.loadComponent();
     });
 
-    this.goModalService.modalOpen.subscribe((value) => {
+    this.goModalService.modalOpen.subscribe((value: boolean) => {
       this.opened = value;
     });
   }
@@ -69,6 +70,9 @@ export class GoModalComponent implements OnInit {
     } else {
       this.modalSize = this.defaultModalSize;
     }
+
+    // set content padding if provided
+    this.noContentPadding = componentRef.instance['noContentPadding'];
   }
 
   /**
@@ -82,11 +86,11 @@ export class GoModalComponent implements OnInit {
     }
   }
 
-  closeModal() {
+  closeModal(): void {
     this.goModalService.toggleModal(false);
   }
 
-  goModalClasses() {
-    return { 'go-modal--visible': this.opened }
+  goModalClasses(): object {
+    return { 'go-modal--visible': this.opened };
   }
 }

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.module.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.module.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { GoModalComponent } from './go-modal.component';
 import { GoModalDirective } from './go-modal.directive';
 
-import { GoIconModule } from '../go-icon/go-icon.module';
+import { GoIconButtonModule } from '../go-icon-button/go-icon-button.module';
 
 @NgModule({
   declarations: [
@@ -13,7 +13,7 @@ import { GoIconModule } from '../go-icon/go-icon.module';
   ],
   imports: [
     CommonModule,
-    GoIconModule
+    GoIconButtonModule
   ],
   exports: [GoModalComponent]
 })

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.html
@@ -35,6 +35,13 @@
         </p>
       </div>
 
+      <div class="go-column go-column--100">
+        <h4 class="go-heading-4">noContentPadding</h4>
+        <p class="go-body-copy go-body-copy--no-margin">
+          <code class="code-block--inline">noContentPadding</code> determines whether or not to render padding on the modal content. Defaults to false.
+        </p>
+      </div>
+
       <div class="go-column go-column--100 go-column--no-padding">
         <h3 class="go-heading-3">Setup</h3>
         <p class="go-body-copy">To use the modal anywhere in the app, you must first add it to the app level. This should only be done once per application.</p>
@@ -136,6 +143,25 @@
       <div class="go-column go-column--25">
         <h4 class="go-heading-4">XL View</h4>
         <go-button (handleClick)="openXlModal()">Click Me</go-button>
+      </div>
+
+    </div>
+  </go-card>
+
+  <go-card class="go-column go-column--100">
+    <header go-card-header>
+      <h2 class="go-heading-2">Modal Padding</h2>
+    </header>
+    <div class="go-container" go-card-content>
+
+      <div class="go-column go-column--75">
+        <h4 class="go-heading-4">Code</h4>
+        <code [highlight]="ex_ModalDocsNoPadding"></code>
+      </div>
+
+      <div class="go-column go-column--25">
+        <h4 class="go-heading-4">View</h4>
+        <go-button (handleClick)="openNoPaddingModal()">Click Me</go-button>
       </div>
 
     </div>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
@@ -80,6 +80,14 @@ export class ModalDocsComponent {
   this.goModalService.openModal(ModalTestComponent, { modalTitle: 'XL Modal', modalSize: 'xl', content: 'This is a xl modal' });
   `;
 
+  ex_ModalDocsNoPadding: string = `
+  this.goModalService.openModal(ModalTestComponent, {
+    modalTitle: 'No Padding Example',
+    content: 'This area has no padding',
+    noContentPadding: true
+  });
+  `;
+
   constructor(private goModalService: GoModalService) { }
 
   openModal(): void {
@@ -92,6 +100,14 @@ export class ModalDocsComponent {
 
   openXlModal(): void {
     this.goModalService.openModal(ModalTestComponent, { modalTitle: 'XL Modal', modalSize: 'xl', content: 'This is a xl modal' });
+  }
+
+  openNoPaddingModal(): void {
+    this.goModalService.openModal(ModalTestComponent, {
+      modalTitle: 'No Padding Example',
+      content: 'This area has no padding',
+      noContentPadding: true
+    });
   }
 
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The modal content has a persistent padding. This makes it difficult in some instances to get correct alignment.

Closes #496 

## What is the new behavior?
Adds a `noContentPadding` binding that defaults to `false`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No