### PR TITLE
allow filter pills in table to wrap

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.scss
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.scss
@@ -284,5 +284,6 @@
 //=====================
 .go-table__filter-container {
   display: flex;
+  flex-wrap: wrap;
   padding: 0 1.25rem;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you have a lot of filter pills in the table, the get all squished together instead of wrapping to the next line:
<img width="1188" alt="Tangoe Design System 2020-03-04 12-51-17" src="https://user-images.githubusercontent.com/5261826/75907758-dbe91b00-5e16-11ea-9fc4-9807ca817bbe.png">

Issue Number: N/A


## What is the new behavior?
Adding the flex-wrap property allows for the pills to wrap nicely:
<img width="965" alt="Tangoe Design System 2020-03-04 12-52-11" src="https://user-images.githubusercontent.com/5261826/75907818-ff13ca80-5e16-11ea-8fc6-9b1b48f08556.png">


## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
