### PR TITLE
[Chore] Tab Header Padding

### DIFF
--- a/projects/go-lib/src/lib/components/go-tab/go-tab-group.component.scss
+++ b/projects/go-lib/src/lib/components/go-tab/go-tab-group.component.scss
@@ -9,7 +9,7 @@
   display: inline-flex;
   font-size: 1.125rem;
   font-weight: $weight-regular;
-  padding: $column-gutter--half $column-gutter;
+  padding: $column-gutter--three-quarters $column-gutter;
 
   &:hover {
     background-color: $theme-light-bg-hover;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
~~Docs have been added / updated (for bug fixes / features)~~

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: CSS Change

## What is the current behavior?
Tab headers have `.5rem` vertical padding
Closes #502 

## What is the new behavior?
Adjusted padding to `.75rem` vertically

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No