### PR TITLE
Fix Multiple Side-Nav Accordions Opening Simultaneously

### DIFF
--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.spec.ts
@@ -82,6 +82,15 @@ describe('GoSideNavComponent', () => {
   });
 
   describe('ngOnInit', () => {
+    it('should add an id to only NavGroup items of menuItems', () => {
+      component.ngOnInit();
+
+      expect(Object.keys(component.menuItems[0])).toContain('id');
+      expect(Object.keys(component.menuItems[1])).toContain('id');
+      expect(Object.keys((component.menuItems[1] as NavGroup).subRoutes[1])).toContain('id');
+      expect(Object.keys((component.menuItems[1] as NavGroup).subRoutes[0])).not.toContain('id');
+    });
+
     it('should expand navGroup of route', () => {
       component.ngOnInit();
       expect(component.menuItems[0]['expanded']).toBe(true);

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
@@ -22,6 +22,8 @@ export class GoSideNavComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
+    this.generateIds(this.menuItems);
+
     this.navService.setMenuItems(this.menuItems);
     this.navService.setActiveItem(this.navService.extractBaseUrl(this.router.url));
     this.configureExpanded(this.router.url);
@@ -42,6 +44,15 @@ export class GoSideNavComponent implements OnInit {
   }
 
   //#region Private Methods
+
+  private generateIds(items: (NavGroup | NavItem)[]) {
+    items.forEach(item => {
+      if (item.subRoutes) {
+        item.id = Math.round(Math.random() * 1000000);
+        this.generateIds(item.subRoutes);
+      }
+    });
+  }
 
   private configureExpanded(url: string): void {
     this.menuItems.forEach((item: (NavGroup | NavItem)) => {
@@ -74,7 +85,9 @@ export class GoSideNavComponent implements OnInit {
    */
   private openAccordion(group: NavGroup, item: NavGroup): boolean {
     if (group.subRoutes) {
-      if (group.routeTitle !== item.routeTitle) {
+      if (group.id !== item.id) {
+      // if (group.routeTitle !== item.routeTitle) {
+      // if ((group.routeTitle !== item.routeTitle) || (group.routeIcon !== item.routeIcon)) {
         group.expanded = group.subRoutes.some((subRoute: (NavGroup | NavItem)) => {
           return this.openAccordion((subRoute as NavGroup), item);
         });

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
@@ -45,10 +45,12 @@ export class GoSideNavComponent implements OnInit {
 
   //#region Private Methods
 
-  private generateIds(items: (NavGroup | NavItem)[]) {
-    items.forEach(item => {
-      if (item.subRoutes) {
-        item.id = Math.round(Math.random() * 1000000);
+  // This recursively adds ids to all NavGroups. We need these ids below within openAccordion()
+  // when checking which accordions should be closed upon clicking a NavGroup.
+  private generateIds(items: (NavGroup | NavItem)[]): void {
+    items.forEach((item: (NavGroup | NavItem)) => {
+      if ('subRoutes' in item) {
+        item.id = `${item.routeTitle}-${Math.round(Math.random() * 1000000)}`;
         this.generateIds(item.subRoutes);
       }
     });
@@ -86,8 +88,6 @@ export class GoSideNavComponent implements OnInit {
   private openAccordion(group: NavGroup, item: NavGroup): boolean {
     if (group.subRoutes) {
       if (group.id !== item.id) {
-      // if (group.routeTitle !== item.routeTitle) {
-      // if ((group.routeTitle !== item.routeTitle) || (group.routeIcon !== item.routeIcon)) {
         group.expanded = group.subRoutes.some((subRoute: (NavGroup | NavItem)) => {
           return this.openAccordion((subRoute as NavGroup), item);
         });

--- a/projects/go-lib/src/lib/components/go-side-nav/nav-group.model.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/nav-group.model.ts
@@ -3,7 +3,7 @@ import { NavItem } from './nav-item.model';
 export interface NavGroup {
   description?: string;
   expanded?: boolean;
-  id?: number;
+  id?: string;
   routeActive?: boolean;
   routeIcon?: string;
   routeTitle: string;

--- a/projects/go-lib/src/lib/components/go-side-nav/nav-group.model.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/nav-group.model.ts
@@ -3,6 +3,7 @@ import { NavItem } from './nav-item.model';
 export interface NavGroup {
   description?: string;
   expanded?: boolean;
+  id?: number;
   routeActive?: boolean;
   routeIcon?: string;
   routeTitle: string;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When clicking a NavGroup item within a `go-side-nav`, if there are other NavGroups with the same `routeTitle`, those accordions will be expanded in addition to the one that was clicked.

Issue Number: #512 

## What is the new behavior?
We can generate an `id` for each NavGroup and then use those, rather than the `routeTitle`s, when checking which NavGroups to expand/close upon clicking a NavGroup.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
