### PR TITLE
[Chore] Close Action Sheet on Panel Click

### DIFF
--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
@@ -3,7 +3,8 @@
    rel="noreferrer"
    [ngClass]="panelClasses()"
    [attr.href]="externalLink"
-   *ngIf="externalLink; else noLink">
+   *ngIf="externalLink; else noLink"
+   (click)="closeActionSheet()">
   <span class="go-panel__title">
     <span *ngIf="icon" class="go-panel__icon material-icons">{{icon}}</span>
     <span class="go-panel__title-text" [innerHtml]="panelContent"></span>

--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.spec.ts
@@ -1,14 +1,25 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GoPanelComponent } from './go-panel.component';
+import { GoActionSheetComponent } from '../go-action-sheet.component';
+import { ElementRef } from '@angular/core';
+
+class MockGoActionSheetComponent extends GoActionSheetComponent {
+  showContent: boolean = false;
+}
 
 describe('GoPanelComponent', () => {
   let component: GoPanelComponent;
   let fixture: ComponentFixture<GoPanelComponent>;
+  let parentComponent: GoActionSheetComponent;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ GoPanelComponent ]
+      declarations: [ GoPanelComponent ],
+      providers: [
+        { provide: ElementRef, useValue: new ElementRef(MockGoActionSheetComponent) },
+        { provide: GoActionSheetComponent, useClass: MockGoActionSheetComponent }
+      ]
     })
     .compileComponents();
   }));
@@ -16,10 +27,39 @@ describe('GoPanelComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GoPanelComponent);
     component = fixture.componentInstance;
+    parentComponent = fixture.debugElement.injector.get(GoActionSheetComponent);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('handleAction', () => {
+    it('should emit an event', () => {
+      spyOn(component.action, 'emit').and.callThrough();
+
+      component.handleAction();
+
+      expect(component.action.emit).toHaveBeenCalled();
+    });
+
+    it('should close the action sheet', () => {
+      parentComponent.showContent = true;
+
+      component.handleAction();
+
+      expect(parentComponent.showContent).toBeFalsy();
+    });
+  });
+
+  describe('closeActionSheet', () => {
+    it('should set parent action sheet\'s showContent to false', () => {
+      parentComponent.showContent = true;
+
+      component.closeActionSheet();
+
+      expect(parentComponent.showContent).toBeFalsy();
+    });
   });
 });

--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { GoActionSheetComponent } from '../go-action-sheet.component';
 
 @Component({
   selector: 'go-panel',
@@ -15,16 +16,21 @@ export class GoPanelComponent {
 
   @Output() action: EventEmitter<void> = new EventEmitter<void>();
 
-  constructor() { }
+  constructor(private parent: GoActionSheetComponent) { }
 
   panelClasses(): object {
     return {
       'go-panel--danger': this.danger,
       'go-panel--header': this.showHeader
-    }
+    };
   }
 
   handleAction(): void {
     this.action.emit();
+    this.closeActionSheet();
+  }
+
+  closeActionSheet(): void {
+    this.parent.showContent = false;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
~~Docs have been added / updated (for bug fixes / features)~~

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently the `go-action-sheet` does not close when a user clicks on a `go-panel` inside.
Closes #514 

## What is the new behavior?
When a user clicks on a `go-panel` inside of a `go-action-sheet` it will close the `go-action-sheet` regardless if the `go-panel` is a link or an action.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
