### PR TITLE
Datepicker Overflow in Modals

### DIFF
--- a/projects/go-lib/src/lib/components/go-datepicker/day-view/go-calendar-day-view.component.html
+++ b/projects/go-lib/src/lib/components/go-datepicker/day-view/go-calendar-day-view.component.html
@@ -39,13 +39,14 @@
       <td *ngFor="let weekDay of dateAdapter.daysOfWeek" class="go-calendar__body--padding"></td>
     </tr>
     <tr *ngFor="let week of weeks" class="go-calendar__row">
-      <td *ngFor="let day of week" class="go-calendar__date" (click)="pickDay(day.value)">
+      <td *ngFor="let day of week" class="go-calendar__date">
         <span *ngIf="!day.translated"></span>
         <button
           class="go-calendar__cell go-calendar__cell--date"
           [disabled]="day.disabled"
           [ngClass]="{'go-calendar__cell--selected': day.selected, 'go-calendar__cell--focused': day.focused}"
           *ngIf="day.translated"
+          (click)="pickDay(day.value)"
         >
           {{day.translated}}
         </button>

--- a/projects/go-lib/src/lib/components/go-datepicker/go-calendar.component.html
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-calendar.component.html
@@ -1,44 +1,50 @@
-<div
-  class="go-calendar"
-  [ngClass]="{'go-calendar--above': displayAbove, 'go-calendar--right': displayFromRight}"
-  *ngIf="opened"
->
-  <div *ngIf="view === 'day'">
-    <go-calendar-day-view
-      [day]="selectedDate"
-      [dateAdapter]="dateAdapter"
-      [month]="currentMonth"
-      [year]="currentYear"
-      [minDate]="minDate"
-      [maxDate]="maxDate"
-      (setMonth)="setMonth($event)"
-      (setYear)="updateYear($event)"
-      (datePicked)="pickDay($event)"
-      (setView)="switchView($event)"
-    ></go-calendar-day-view>
-  </div>
+<div class="go-calendar--wrapper">
+  <div
+    class="go-calendar"
+    [ngClass]="{'go-calendar--above': displayAbove, 'go-calendar--right': displayFromRight, 'go-calendar--append-to-content': appendToContent}"
+    *ngIf="opened">
+    <div *ngIf="view === 'day'">
+      <go-calendar-day-view
+        [day]="selectedDate"
+        [dateAdapter]="dateAdapter"
+        [month]="currentMonth"
+        [year]="currentYear"
+        [minDate]="minDate"
+        [maxDate]="maxDate"
+        (setMonth)="setMonth($event)"
+        (setYear)="updateYear($event)"
+        (datePicked)="pickDay($event)"
+        (setView)="switchView($event)">
+      </go-calendar-day-view>
+    </div>
 
-  <div *ngIf="view === 'year'">
-    <go-calendar-year-view
-      [year]="currentYear"
-      [dateAdapter]="dateAdapter"
-      [minDate]="minDate"
-      [maxDate]="maxDate"
-      (setYear)="updateYear($event)"
-      (setView)="switchView($event)"
-    ></go-calendar-year-view>
+    <div *ngIf="view === 'year'">
+      <go-calendar-year-view
+        [year]="currentYear"
+        [dateAdapter]="dateAdapter"
+        [minDate]="minDate"
+        [maxDate]="maxDate"
+        (setYear)="updateYear($event)"
+        (setView)="switchView($event)">
+      </go-calendar-year-view>
+    </div>
+    
+    <div *ngIf="view === 'month'">
+      <go-calendar-month-view
+        [month]="currentMonth"
+        [dateAdapter]="dateAdapter"
+        [year]="currentYear"
+        [minDate]="minDate"
+        [maxDate]="maxDate"
+        (setMonth)="setMonth($event)"
+        (setView)="switchView($event)"
+        (setYear)="updateYear($event)">
+      </go-calendar-month-view>
+    </div>
   </div>
-  
-  <div *ngIf="view === 'month'">
-    <go-calendar-month-view
-      [month]="currentMonth"
-      [dateAdapter]="dateAdapter"
-      [year]="currentYear"
-      [minDate]="minDate"
-      [maxDate]="maxDate"
-      (setMonth)="setMonth($event)"
-      (setView)="switchView($event)"
-      (setYear)="updateYear($event)"
-    ></go-calendar-month-view>
+  <div
+    *ngIf="appendToContent"
+    class="go-calendar__close-calendar-content"
+    (click)="closeCalendar()">
   </div>
 </div>

--- a/projects/go-lib/src/lib/components/go-datepicker/go-calendar.component.scss
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-calendar.component.scss
@@ -16,3 +16,15 @@
 .go-calendar--right {
   right: 0;
 }
+
+.go-calendar--append-to-content {
+  position: static;
+}
+
+.go-calendar--wrapper {
+  display: flex;
+}
+
+.go-calendar__close-calendar-content {
+  flex-grow: 1;
+}

--- a/projects/go-lib/src/lib/components/go-datepicker/go-calendar.component.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-calendar.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { fadeAnimation } from '../../animations/fade.animation';
 import { GoCalendar } from './go-calendar';
 import { DateAdapter } from './date-adapter';
@@ -22,6 +22,7 @@ export class GoCalendarComponent implements OnDestroy, OnInit {
   subscription: any;
   view: string = 'day';
 
+  @Input() appendToContent: boolean;
   @Input() calendar: GoCalendar;
   @Input() displayAbove: boolean;
   @Input() displayFromRight: boolean;

--- a/projects/go-lib/src/lib/components/go-datepicker/go-calendar.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-calendar.ts
@@ -1,6 +1,7 @@
 import { Subject } from 'rxjs';
 
 export class GoCalendar {
+  private _calendarOpen: boolean = false;
   calendarOpen: Subject<boolean> = new Subject<boolean>();
   selectedDate: Date;
 
@@ -27,7 +28,12 @@ export class GoCalendar {
     return false;
   }
 
+  get isOpen(): boolean {
+    return this._calendarOpen;
+  }
+
   private setCalendarStatus(isOpen: boolean = true): void {
+    this._calendarOpen = isOpen;
     this.calendarOpen.next(isOpen);
   }
 }

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.html
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.html
@@ -22,9 +22,10 @@
     class="go-datepicker__toggle"
     [buttonDisabled]="control.disabled"
     buttonIcon="today"
-    (click)="openDatepicker($event)"
+    (click)="toggleDatepicker($event)"
   ></go-icon-button>
   <go-calendar
+    [appendToContent]="appendToContent"
     (datePicked)="datePicked($event)"
     [maxDate]="max"
     [minDate]="min"

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.scss
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.scss
@@ -4,6 +4,6 @@
 
 .go-datepicker__toggle {
   position: absolute;
-  right: .15rem;
-  top: .15rem;
+  right: .35rem;
+  top: .35rem;
 }

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
@@ -200,14 +200,29 @@ describe('GoDatepickerComponent', () => {
     });
   });
 
-  describe('openDatepicker', () => {
+  describe('toggleDatepicker', () => {
     it('should not open datepicker if control is disabled', () => {
       spyOn(component.goCalendar, 'openCalendar');
 
       component.control.disable();
-      component.openDatepicker(new Event('click'));
+      component.toggleDatepicker(new Event('click'));
       expect(component.goCalendar.openCalendar).not.toHaveBeenCalled();
     });
-    // TODO figure out how to test the rest of this
+
+    it('should open if calendar is previously closed', () => {
+      component.goCalendar.closeCalendar();
+
+      component.toggleDatepicker(new Event('click'));
+
+      expect(component.goCalendar.isOpen).toBe(true);
+    });
+
+    it('should close calendar if previously opened', () => {
+      component.goCalendar.openCalendar(new Date());
+
+      component.toggleDatepicker(new Event('click'));
+
+      expect(component.goCalendar.isOpen).toBe(false);
+    });
   });
 });

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.ts
@@ -19,6 +19,7 @@ export class GoDatepickerComponent implements OnDestroy, OnInit {
   selectedDate: string;
   subscription: any;
 
+  @Input() appendToContent: boolean = false;
   @Input() control: FormControl;
   @Input() hints: string[];
   @Input() key: string;
@@ -67,7 +68,7 @@ export class GoDatepickerComponent implements OnDestroy, OnInit {
     }
   }
 
-  public openDatepicker(event: Event): void {
+  public toggleDatepicker(event: Event): void {
     event.stopPropagation();
 
     // Have to disable this here because of the event that we need to stop propagation on.
@@ -75,11 +76,15 @@ export class GoDatepickerComponent implements OnDestroy, OnInit {
       return;
     }
 
-    const distance: object = this.datepickerInput.nativeElement.getBoundingClientRect();
+    if (this.goCalendar.isOpen) {
+      this.goCalendar.closeCalendar();
+    } else {
+      const distance: object = this.datepickerInput.nativeElement.getBoundingClientRect();
 
-    this.displayFromRight = window.innerWidth - distance['left'] < 350;
-    this.displayAbove = window.innerHeight - distance['top'] < 350;
-    this.goCalendar.openCalendar(this.control.value);
+      this.displayFromRight = window.innerWidth - distance['left'] < 350;
+      this.displayAbove = window.innerHeight - distance['top'] < 350 && !this.appendToContent;
+      this.goCalendar.openCalendar(this.control.value);
+    }
   }
 
   public datePicked(date: Date): void {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/datepicker-docs/datepicker-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/datepicker-docs/datepicker-docs.component.html
@@ -429,4 +429,40 @@
 
     </div>
   </go-card>
+
+  <go-card id="form-datepicker-append-to-content" class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2">Component Append To Content</h2>
+    </ng-container>
+    <div class="go-container" go-card-content>
+      <div class="go-column go-column--100">
+        <p class="go-body-copy go-body-copy--no-margin">
+          There are times where overflow is a problem with the datepicker, especially when regarding using a datepicker
+          within a modal. If that's the case we can set <code class="code-block--inline">[appendToContent]="true"</code> 
+          and the calendar will be added to the content of the page instead of positioning over the content on the page.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <div class="go-container">
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">View</h4>
+            <go-datepicker
+              [control]="dob9"
+              label="Date of Birth"
+              [appendToContent]="true"
+            ></go-datepicker>
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+            <code
+              [highlight]="appendToContentExample"
+              class="code-block--no-bottom-margin"
+            ></code>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </go-card>
 </section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/datepicker-docs/datepicker-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/datepicker-docs/datepicker-docs.component.ts
@@ -14,6 +14,7 @@ export class DatepickerDocsComponent implements OnInit {
   dob6: FormControl = new FormControl({ value: '', disabled: true });
   dob7: FormControl = new FormControl('');
   dob8: FormControl = new FormControl('');
+  dob9: FormControl = new FormControl('');
   locale: FormControl = new FormControl('');
   max: FormControl = new FormControl('');
   min: FormControl = new FormControl('');
@@ -139,6 +140,14 @@ export class DatepickerDocsComponent implements OnInit {
     [control]="min"
     label="Date of Birth"
     minDate="5/10/2000"
+  ></go-datepicker>
+  `;
+
+  appendToContentExample: string = `
+  <go-datepicker
+    [control]="dob"
+    label="Date of Birth"
+    [appendToContent]="true"
   ></go-datepicker>
   `;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #511 


## What is the new behavior?
Adds a new binding for the datepicker to allow for appending to the content instead of showing the calendar over the content on the page.

* Small bugfix where clicking in between two dates, or clicking at the beginning of the month or end of the month where there are no days would close the calendar and error

* Small bugfix where clicking on the calendar icon once the calendar is open wouldn't close the calendar


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
