### PR TITLE
BUGFIX: Go Off Canvas Header Color in Mobile

### DIFF
--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.component.scss
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.component.scss
@@ -39,6 +39,7 @@
 .go-off-canvas__title {
   flex-grow: 1;
   padding-right: .5rem;
+  color: $theme-dark-color;
 }
 
 .go-off-canvas__button {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Color change

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, we are having issues in Mobile where the header for the Go Off Canvas is showing as
dark rather than white by default. This commit should fix this.

Issue Number: N/A


## What is the new behavior?

Header appears as white instead of dark

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No