### PR TITLE
Add positive, negative, and neutral options to iconModifier of go-icon

### DIFF
--- a/projects/go-lib/src/lib/components/go-icon/go-icon.component.scss
+++ b/projects/go-lib/src/lib/components/go-icon/go-icon.component.scss
@@ -48,6 +48,30 @@ $icon-sizes: (small: 1rem, medium: 1.25rem, large: 1.5rem);
   }
 }
 
+.go-icon--positive {
+  color: $ui-color-positive;
+
+  &.go-icon--disabled {
+    color: rgba($ui-color-positive, .7);
+  }
+}
+
+.go-icon--negative {
+  color: $ui-color-negative;
+
+  &.go-icon--disabled {
+    color: rgba($ui-color-negative, .7);
+  }
+}
+
+.go-icon--neutral {
+  color: $ui-color-neutral;
+
+  &.go-icon--disabled {
+    color: rgba($ui-color-neutral, .7);
+  }
+}
+
 @each $name, $size in $icon-sizes {
   .go-icon--#{$name} {
     font-size: $size;

--- a/projects/go-lib/src/lib/components/go-icon/go-icon.component.scss
+++ b/projects/go-lib/src/lib/components/go-icon/go-icon.component.scss
@@ -2,6 +2,13 @@
 @import '../../../styles/mixins';
 
 $icon-sizes: (small: 1rem, medium: 1.25rem, large: 1.5rem);
+$icon-colors: (
+  dark: $base-dark,
+  light: $base-light,
+  positive: $ui-color-positive,
+  negative: $ui-color-negative,
+  neutral: $ui-color-neutral
+);
 
 // This .go-icon selector styles are borrowed verbatim from the material
 // icons documentation and applied to our own bem style block class.
@@ -32,49 +39,18 @@ $icon-sizes: (small: 1rem, medium: 1.25rem, large: 1.5rem);
   font-feature-settings: 'liga';
 }
 
-.go-icon--dark {
-  color: $base-dark;
-
-  &.go-icon--disabled {
-    color: rgba($base-dark, .7);
-  }
-}
-
-.go-icon--light {
-  color: $base-light;
-
-  &.go-icon--disabled {
-    color: rgba($base-light, .7);
-  }
-}
-
-.go-icon--positive {
-  color: $ui-color-positive;
-
-  &.go-icon--disabled {
-    color: rgba($ui-color-positive, .7);
-  }
-}
-
-.go-icon--negative {
-  color: $ui-color-negative;
-
-  &.go-icon--disabled {
-    color: rgba($ui-color-negative, .7);
-  }
-}
-
-.go-icon--neutral {
-  color: $ui-color-neutral;
-
-  &.go-icon--disabled {
-    color: rgba($ui-color-neutral, .7);
-  }
-}
-
 @each $name, $size in $icon-sizes {
   .go-icon--#{$name} {
     font-size: $size;
+  }
+}
+
+@each $name, $color in $icon-colors {
+  .go-icon--#{$name} {
+    color: $color;
+      &.go-icon--disabled {
+        color: rgba($color, .7);
+      }
   }
 }
 

--- a/projects/go-lib/src/lib/components/go-icon/go-icon.component.ts
+++ b/projects/go-lib/src/lib/components/go-icon/go-icon.component.ts
@@ -9,7 +9,7 @@ export class GoIconComponent implements OnChanges {
   classObject: object = {};
 
   @Input() icon: string;
-  @Input() iconModifier: string;
+  @Input() iconModifier: 'light' | 'dark' | 'positive' | 'negative' | 'neutral';
   @Input() iconClass: string;
   @Input() disabled: boolean = false;
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/icon-docs/icon-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/icon-docs/icon-docs.component.html
@@ -47,9 +47,10 @@
         <h4 class="go-heading-4">iconModifier</h4>
         <p class="go-body-copy">
           The <code class="code-block--inline">iconModifier</code> binding accepts a value of 
-          <code class="code-block--inline">'light'</code> or <code class="code-block--inline">'dark'</code> 
-          and will modify the icon color. This can be useful when using the icon on different backgrounds. 
-          The icon will inherit its color otherwise.
+          <code class="code-block--inline">'light'</code>, <code class="code-block--inline">'dark'</code>, 
+          <code class="code-block--inline">'positive'</code>, <code class="code-block--inline">'negative'</code>, 
+          or <code class="code-block--inline">'neutral'</code>
+          and will modify the icon color. The icon will inherit its color otherwise.
         </p>
       </div>
 
@@ -92,9 +93,11 @@
       <h4 class="go-heading-4">Code</h4>
       <code [highlight]="modifiedExample"></code>
       <h4 class="go-heading-4">View</h4>
-      <div class="dark-example-area">
-        <go-icon icon="home" iconModifier="light"></go-icon>
-      </div>
+      <go-icon icon="home" iconModifier="light" class="dark-example-area"></go-icon>
+      <go-icon icon="home" iconModifier="dark"></go-icon>
+      <go-icon icon="check" iconModifier="positive"></go-icon>
+      <go-icon icon="close" iconModifier="negative"></go-icon>
+      <go-icon icon="help" iconModifier="neutral"></go-icon>
     </ng-container>
   </go-card>
   

--- a/projects/go-style-guide/src/app/features/ui-kit/components/icon-docs/icon-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/icon-docs/icon-docs.component.ts
@@ -10,7 +10,7 @@ export class IconDocsComponent {
 
   componentBindings: string = `
   @Input() icon: string;
-  @Input() iconModifier: string;
+  @Input() iconModifier: 'light' | 'dark' | 'positive' | 'negative' | 'neutral';
   @Input() iconClass: string;
   `;
 
@@ -22,7 +22,11 @@ export class IconDocsComponent {
   `;
 
   modifiedExample: string = `
-  <go-icon icon="home" iconModifier="light"></go-icon>
+  <go-icon icon="home" iconModifier="light" class="dark-example-area"></go-icon>
+  <go-icon icon="home" iconModifier="dark"></go-icon>
+  <go-icon icon="check" iconModifier="positive"></go-icon>
+  <go-icon icon="close" iconModifier="negative"></go-icon>
+  <go-icon icon="help" iconModifier="neutral"></go-icon>
   `;
 
   overriddenStyles: string = `


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #525 


## What is the new behavior?
Added the ability to pass 'positive', 'negative', and 'neutral' to the the `iconModifier` binding of `go-icon`, which alter the color of the icon.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
