### PR TITLE
Fix console error when setting custom attributes on go-nav-items

### DIFF
--- a/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-nav-item/go-nav-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnInit, Renderer2, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, OnInit, Renderer2, ViewChild } from '@angular/core';
 import { distinctUntilKeyChanged } from 'rxjs/operators';
 import { GoConfigInterface } from '../../../go-config.model';
 import { GoConfigService } from '../../../go-config.service';
@@ -10,7 +10,7 @@ import { NavItem } from '../nav-item.model';
   templateUrl: './go-nav-item.component.html',
   styleUrls: ['./go-nav-item.component.scss']
 })
-export class GoNavItemComponent implements OnInit {
+export class GoNavItemComponent implements AfterViewInit, OnInit {
   brandColor: string;
 
   @Input() navItem: NavItem;
@@ -25,14 +25,16 @@ export class GoNavItemComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    if (this.navItem.attributes) {
-      this.navService.setAttributes(this.navItem.attributes, this.navItemRef, this.renderer);
-    }
-
     this.configService.config
       .pipe(distinctUntilKeyChanged('brandColor'))
       .subscribe((value: GoConfigInterface) => {
         this.brandColor = value.brandColor;
       });
+  }
+
+  ngAfterViewInit(): void {
+    if (this.navItem.attributes) {
+      this.navService.setAttributes(this.navItem.attributes, this.navItemRef, this.renderer);
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #540 
Adding `attributes` to `go-nav-item`s throws a console error and causes the sub-navs in which they appear to fail to render correctly.

## What is the new behavior?
Able to add `attributes` to `go-nav-item`s without throwing an error.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->