### PR TITLE
Removes text decoration from go-link

### DIFF
--- a/projects/go-lib/src/styles/_typography.scss
+++ b/projects/go-lib/src/styles/_typography.scss
@@ -29,9 +29,9 @@ body {
 }
 
 .go-link {
-  border-bottom: 1px solid;
   color: $theme-light-color;
   display: inline-block;
+  text-decoration: underline;
   transition: $global-transition-duration $global-transition-timing;
 
   &:active,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Interface Style Changes


## What is the current behavior?
Currently using the go-link class from goponents does not produce a link that looks the same as links in the style guide do. This is because in the style guide we have a style in there that removes the text decoration from all link tags.

## What is the new behavior?
We remove the bottom border from go-link and add text decoration to make all the same styles are being applied to link tags in the style guide.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
