### PR TITLE
Add classes for horizontal rules within go-cards

### DIFF
--- a/projects/go-lib/src/styles/_globals.scss
+++ b/projects/go-lib/src/styles/_globals.scss
@@ -26,7 +26,9 @@
 }
 
 .go-hr {
-  border: 1px solid $theme-light-app-bg;
+  background: $theme-light-app-bg;
+  border: 0;
+  height: 1px;
   margin: 1rem -1rem;
 }
 

--- a/projects/go-lib/src/styles/_globals.scss
+++ b/projects/go-lib/src/styles/_globals.scss
@@ -24,3 +24,13 @@
     width: 0;
   }
 }
+
+.go-hr {
+  border: 1px solid $theme-light-app-bg;
+  margin: 1rem -1rem;
+}
+
+.go-hr--allow-padding {
+  margin-right: 0;
+  margin-left: 0;
+}

--- a/projects/go-style-guide/src/app/features/ui-kit/components/card-docs/card-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/card-docs/card-docs.component.html
@@ -50,4 +50,34 @@
       <code [highlight]="showHeaderExample"></code>
     </ng-container>
   </go-card>
+
+  <go-card class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2">With Horizontal Rules</h2>
+    </ng-container>
+    <ng-container go-card-content>
+      <h4 class="go-heading-4">Full Width</h4>
+      <p class="go-body-copy">
+        A horizontal rule that spans the entire width of the card can be implemented by adding the
+        <code class="code-block--inline">go-hr</code> class on an <code class="code-block--inline">hr</code> tag
+        within the card's <code class="code-block--inline">go-card-content</code>.
+      </p>
+      <hr class="go-hr">
+      <code
+        [highlight]="hrExample"
+        class="code-block">
+      </code>
+
+      <h4 class="go-heading-4">With Padding</h4>
+      <p class="go-body-copy">
+        Also adding the <code class="code-block--inline">go-hr--padding</code> modifier class will
+        cause the width of the horizontal rule to respect the padding of the card containing it.
+      </p>
+      <hr class="go-hr go-hr--allow-padding">
+      <code
+        [highlight]="hrAllowPaddingExample"
+        class="code-block">
+      </code>
+    </ng-container>
+  </go-card>
 </section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/card-docs/card-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/card-docs/card-docs.component.ts
@@ -34,6 +34,14 @@ export class CardDocsComponent {
   </go-card>
   `;
 
+  hrExample: string = `
+    <hr class="go-hr">
+  `;
+
+  hrAllowPaddingExample: string = `
+    <hr class="go-hr go-hr--allow-padding">
+  `;
+
   constructor() { }
 
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #520 


## What is the new behavior?
Classes for styling `hr`s within `go-card`s have been added, both for when the `hr` should span the full width of the card and when it should respect the card's padding.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

