### PR TITLE
Set searchTerm value even if passed in after init

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -903,6 +903,16 @@ describe('GoTableComponent', () => {
 
       expect(component.pages).toEqual(pages);
     });
+
+    it('should reset the searchTerm if passed in', () => {
+      component.searchTerm.reset();
+      component.tableConfig.searchConfig.searchTerm = 'koala';
+      component.tableConfig.searchConfig.searchable = true;
+
+      component.renderTable();
+
+      expect(component.searchTerm.value).toEqual(component.tableConfig.searchConfig.searchTerm);
+    });
   });
 
   describe('clearSearch', () => {

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -117,6 +117,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
       this.setTotalCount();
       this.handleSort();
       this.setPage(this.localTableConfig.pageConfig.offset);
+      this.setSearchTerm();
     }
 
     this.showTable = Boolean(this.tableConfig);
@@ -428,10 +429,6 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   private setupSearch(): void {
-    if (this.localTableConfig.searchConfig.searchTerm) {
-      this.searchTerm.setValue(this.localTableConfig.searchConfig.searchTerm);
-    }
-
     this.searchTerm.valueChanges.pipe(
       debounceTime(this.localTableConfig.searchConfig.debounce),
       distinctUntilChanged()
@@ -443,6 +440,13 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
         this.tableChangeOutcome();
       }
     });
+    this.setSearchTerm();
+  }
+
+  private setSearchTerm(): void {
+    if (this.localTableConfig.searchConfig.searchTerm) {
+      this.searchTerm.setValue(this.localTableConfig.searchConfig.searchTerm);
+    }
   }
 
   private performSearch(searchTerm: string): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you update 
Issue Number: #551 


## What is the new behavior?
SearchTerm will show in searchbar even if programmatically set after table is initialized. 

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
