### PR TITLE
Reset page offset when doing remote search

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -1015,6 +1015,20 @@ describe('GoTableComponent', () => {
       expect(component.localTableConfig.tableData).toEqual(fakeTableData);
     }));
 
+    it('resets the page offset if datamode is server', fakeAsync(() => {
+      component.tableConfig.searchConfig.searchable = true;
+      component.tableConfig.dataMode = GoTableDataSource.server;
+
+      component.renderTable();
+      component.ngOnInit();
+
+      component.localTableConfig.pageConfig.offset = 10;
+
+      component.searchTerm.setValue('koala bear');
+      tick(501);
+      expect(component.localTableConfig.pageConfig.offset).toEqual(0);
+    }));
+
     it('emits a table change event if search term changes', fakeAsync(() => {
       spyOn(component.tableChange, 'emit');
 

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -437,7 +437,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
       if (!this.isServerMode()) {
         this.performSearch(searchTerm ? searchTerm.toLowerCase() : '');
       } else {
-        this.tableChangeOutcome();
+        this.setFirstPage();
       }
     });
     this.setSearchTerm();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When entering a search term on a table that is in server mode, the page offset does not get reset. This is resulting in a bug where the api is being called with an offset that is larger than the filtered dataset, resulting in no data being shown.

Issue Number: I'm too lazy to rewrite this info in an issue.


## What is the new behavior?
This PR resets the page offset before emitting the table change event, as is being done when the table is in client mode.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I was listening to the Game of Thrones soundtrack while fixing this bug. It helped.