### PR TITLE
Remove publishing tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test_app": "ng test go-tester",
     "npm_pack": "cd dist/go-lib && npm pack",
     "package": "npm run build_lib && npm run npm_pack",
-    "publish": "npm run package && cd dist/go-lib && npm publish",
+    "publish": "npm run build_lib && cd dist/go-lib && npm publish",
     "publish_local": "npm run package && node ./local_install.js",
     "sass-lint": "node_modules/.bin/sass-lint -c .sass-lint.yml",
     "style_guide": "ng serve --project=go-style-guide",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are running `npm pack` before publishing. `npm pack` is meant for local testing, and the resulting tarball has no effect on the package when other apps install from npm. So although there is no harm done, it is just an unnecessary step.

Issue Number: #51 


## What is the new behavior?
The publish script does not call `npm pack`

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I have nothing useful to add here. Sorry.