### PR TITLE
Only rerender table if tableConfig changes

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -11,7 +11,7 @@ import { RowSelectionEvent, SelectionMode, SelectionState } from './go-table-sel
 import { GoTableSortConfig, SortDirection } from './go-table-sort.model';
 
 import { GoTableComponent } from './go-table.component';
-import { Component } from '@angular/core';
+import { Component, SimpleChange } from '@angular/core';
 import { GoTableColumnComponent } from './go-table-column.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { GoSelectModule } from '../go-select/go-select.module';
@@ -1047,7 +1047,7 @@ describe('GoTableComponent', () => {
     it('should render table', () => {
       spyOn(component, 'renderTable');
 
-      component.ngOnChanges();
+      component.ngOnChanges({ tableConfig: {} as SimpleChange });
 
       expect(component.renderTable).toHaveBeenCalled();
     });

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -11,6 +11,7 @@ import {
   OnInit,
   Output,
   QueryList,
+  SimpleChanges,
   TemplateRef,
   ViewChild
 } from '@angular/core';
@@ -91,8 +92,10 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit {
     }
   }
 
-  ngOnChanges(): void {
-    this.renderTable();
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.tableConfig) {
+      this.renderTable();
+    }
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the table rerenders (using `this.renderTable`) on any change to the component. This is causing an issue when a property other that `tableConfig` changes (e.g. `isLoading`). 

For example, if the table is in server mode, and the user types in a search, we want to set `isLoading` to true while we are making the api call with the search term. In the meantime, since `isLoading` changed, the table will will call `renderTable` and use the _existing table config_, which may contain the _previous_ search term, and will just reset the search box to the previous value.

Issue Number: this is a big issue 😉 


## What is the new behavior?
This PR adds a guard clause to only call `this.renderTable` in the event that the `tableConfig` input changes.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [ ] No
- [x] 🤞 


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
