### PR TITLE
[Bug] Fix Textarea Sizing

### DIFF
--- a/projects/go-lib/src/styles/_mixins.scss
+++ b/projects/go-lib/src/styles/_mixins.scss
@@ -63,6 +63,7 @@ $z-index: (
   font-family: inherit;
   font-size: .875rem;
   letter-spacing: .5pt;
+  max-width: 100%;
   outline: none;
   width: 100%;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
~~Docs have been added / updated (for bug fixes / features)~~

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The `go-textarea` could be resized past 100% of it's parent.
Issue Number: #578 

## What is the new behavior?
The `go-textarea` will now only expand to up to `100%` of it's parent's width.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No