### PR TITLE
[Feature] Toast Templates

### DIFF
--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -12,13 +12,26 @@
     [ngClass]="{ 'go-toast-content--no-title': !header }">
     <h4
       class="go-heading-4 go-toast-content__title"
-      *ngIf="header">
-      {{ header }}
+      *ngIf="header || headerContent">
+      <ng-container *ngIf="headerContent; else headerContentElse">
+        <ng-container *ngTemplateOutlet="headerContent"></ng-container>
+      </ng-container>
+      <ng-template #headerContentElse>
+        {{ header }}
+      </ng-template>
     </h4>
-    <p
-      class="go-toast-content__message"
-      [innerHTML]="message">
-    </p>
+
+    <ng-container *ngIf="messageContent; else messageContentElse">
+      <p class="go-toast-content__message">
+       <ng-container *ngTemplateOutlet="messageContent"></ng-container>
+      </p>
+    </ng-container>
+    <ng-template #messageContentElse>
+      <p
+        class="go-toast-content__message"
+        [innerHTML]="message">
+      </p>
+    </ng-template>
   </div>
   <div
     class="go-toast-dismiss"

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
@@ -1,4 +1,12 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  ContentChild,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef
+} from '@angular/core';
 
 @Component({
   selector: 'go-toast',
@@ -15,8 +23,20 @@ export class GoToastComponent implements OnInit {
   @Input() message: string;
   @Input() type: string;
   @Input() showToastActions: boolean = false;
-  
-  @Output() handleDismiss = new EventEmitter();
+
+  @Output() handleDismiss: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * Used to render Angular components and HTML inside of the header
+   * instead of using just a string
+   */
+  @ContentChild('headerContent') headerContent: TemplateRef<any>;
+
+  /**
+   * Used to render Angular components and HTML inside of the message
+   * instead of using just a string
+   */
+  @ContentChild('messageContent') messageContent: TemplateRef<any>;
 
   ngOnInit(): void {
     this.statusClass = this.getStatus();

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
@@ -143,6 +143,7 @@
       <go-button (handleClick)="sendToast()">Make Toast</go-button>
     </ng-container>
   </go-card>
+
   <go-card class="go-column go-column--100">
     <ng-container go-card-header>
       <h2 class="go-heading-2">Button Example</h2>
@@ -157,6 +158,7 @@
       <code [highlight]="action_btn_html"></code>
     </ng-container>
   </go-card>
+
   <go-toast 
     type="neutral" 
     header="Hey!"
@@ -177,4 +179,57 @@
       </div>
     </ng-container>
   </go-toast>
+
+  <go-card class="go-column go-column--100" id="header-template">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-margin">Header Template</h2>
+    </ng-container>
+    <ng-container go-card-content>
+      <p class="go-body-copy">
+        Instead of passing just a string to the header of the toast, an
+        Angular template can be utilized. This will allow use of Angular components
+        and HTML inside of the header of the toast.
+        <strong>
+          Note: This will replace anything passed into the <code class="code-block code-block--inline">header</code> input.
+        </strong>
+      </p>
+      <h4 class="go-heading-4">component.html</h4>
+      <code [highlight]="toast_header_template_html"></code>
+    </ng-container>
+  </go-card>
+
+  <go-toast 
+    class="go-column go-column--100"
+    message="This toast is an example that uses a header template">
+    <ng-template #headerContent>
+      Header Content Template <go-icon icon="home"></go-icon>
+    </ng-template>
+  </go-toast>
+
+  <go-card class="go-column go-column--100" id="message-template">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2">Message Template</h2>
+    </ng-container>
+    <ng-container go-card-content>
+      <p class="go-body-copy">
+        Instead of passing just a string to the message of the toast, an
+        Angular template can be utilized. This will allow use of Angular components
+        and HTML inside of the message of the toast.
+        <strong>
+          Note: This will replace anything passed into the <code class="code-block code-block--inline">message</code> input.
+        </strong>
+      </p>
+      <h4 class="go-heading-4">component.html</h4>
+      <code [highlight]="toast_message_template_html"></code>
+    </ng-container>
+  </go-card>
+
+  <go-toast 
+    class="go-column go-column--100"
+    header="Message Content Template">
+    <ng-template #messageContent>
+      This toast is an example that uses a message template <go-icon icon="home"></go-icon>
+    </ng-template>
+  </go-toast>
+
 </section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
@@ -104,6 +104,24 @@ export class ToastDocsComponent {
   <go-toaster></go-toaster>
   `;
 
+  toast_header_template_html: string = `
+  <go-toast
+    message="This toast is an example that uses a header template">
+    <ng-template #headerContent>
+      Header Content Template <go-icon icon="home"></go-icon>
+    </ng-template>
+  </go-toast>
+  `;
+
+  toast_message_template_html: string = `
+  <go-toast
+    header="Message Content Template">
+    <ng-template #messageContent>
+      This toast is an example that uses a message template <go-icon icon="home"></go-icon>
+    </ng-template>
+  </go-toast>
+  `;
+
   constructor(private toasterService: GoToasterService) { }
 
   dismissed(): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The toast `header` input only accepts a string and the `message` input only accepts an html `string`

Issue Number: N/A

## What is the new behavior?
The `header` and `message` inputs are untouched, but the ability to specify templates for both `headerContent` and `messageContent` exists. These override the `header` and `message` inputs respectively.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
