### PR TITLE
[Bug] go-button Icon Only Height Incorrect

### DIFF
--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -28,6 +28,7 @@
   font-size: .875rem;
   font-weight: $weight-regular;
   letter-spacing: .015rem;
+  line-height: 1.2;
   outline: none;
   padding: calc(0.625rem - 1px) $column-gutter;
   position: relative;
@@ -45,7 +46,7 @@
 }
 
 .go-button--icon-only {
-  padding: calc(.625rem + (.3125rem / 2) - 1px);
+  padding: calc(.625rem - 1px) .625rem;
 
   .go-button__icon {
     padding: 0;

--- a/projects/go-lib/src/lib/components/go-icon/go-icon.component.scss
+++ b/projects/go-lib/src/lib/components/go-icon/go-icon.component.scss
@@ -18,7 +18,7 @@ $icon-colors: (
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: normal;
-  line-height: 1;
+  line-height: inherit;
   text-transform: none;
   letter-spacing: normal;
   word-wrap: normal;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
~~Tests for the changes have been added (for bug fixes / features)~~
~~Docs have been added / updated (for bug fixes / features)~~

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
In some cases, a `go-button` with only an icon could have a different height than that of a `go-button` with text.

Related to issue: #563 

## What is the new behavior?
Fixed it so that all `go-button` should share the same height.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
