### PR TITLE
Add directive for use in adding ability to copy permalinks to doc examples

### DIFF
--- a/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.spec.ts
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.spec.ts
@@ -10,7 +10,7 @@ import { GoIconModule } from '../go-icon/go-icon.module';
 })
 class TestParentComponent {}
 
-fdescribe('GoCopyDocLinkDirective', () => {
+describe('GoCopyDocLinkDirective', () => {
   let fixture: ComponentFixture<TestParentComponent>;
   let elementRef: ElementRef;
   let goCopyComponent: GoCopyComponent;

--- a/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.spec.ts
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.spec.ts
@@ -1,0 +1,54 @@
+import { Component, ElementRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { GoCopyDocLinkDirective } from './go-copy-doc-link.directive';
+import { GoCopyComponent } from './go-copy.component';
+import { GoCopyModule } from './go-copy.module';
+import { GoIconModule } from '../go-icon/go-icon.module';
+
+@Component({
+  template: `<go-copy cardId="testId" goCopyDocLink></go-copy>`
+})
+class TestParentComponent {}
+
+fdescribe('GoCopyDocLinkDirective', () => {
+  let fixture: ComponentFixture<TestParentComponent>;
+  let elementRef: ElementRef;
+  let goCopyComponent: GoCopyComponent;
+  let directive: GoCopyDocLinkDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TestParentComponent
+      ],
+      imports: [
+        GoCopyModule,
+        GoIconModule
+      ]
+    });
+
+    fixture = TestBed.createComponent(TestParentComponent);
+    elementRef = fixture.elementRef;
+    goCopyComponent = TestBed.createComponent(GoCopyComponent).componentInstance;
+    directive = new GoCopyDocLinkDirective(elementRef, goCopyComponent);
+  });
+
+  it('creates an instance', () => {
+    expect(directive).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('adds a class of go-copy--card-header and sets the title of the element', () => {
+      directive.ngOnInit();
+      expect(elementRef.nativeElement.classList).toContain('go-copy--card-header');
+      expect(elementRef.nativeElement.title).toBe('Copy the URL to this card');
+    });
+
+
+    it('sets the text of the element with the current url and an id selector', () => {
+      directive.cardId = 'testId';
+      directive.ngOnInit();
+      expect(goCopyComponent.text).toBe('http://localhost:9876/context.html/#testId');
+    });
+  });
+});

--- a/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.ts
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.ts
@@ -1,22 +1,20 @@
-import { Directive, ElementRef, EventEmitter, OnInit, Output } from '@angular/core';
-import { Router } from '@angular/router';
+import { Directive, ElementRef, Host, OnInit } from '@angular/core';
+import { GoCopyComponent } from './go-copy.component';
 
 @Directive({
   selector: '[goCopyDocLink]'
 })
 export class GoCopyDocLinkDirective implements OnInit {
 
-  @Output() url: EventEmitter<string> = new EventEmitter<string>();
-
   constructor(
     private elementRef: ElementRef,
-    private router: Router
-  ) {
-    this.url.emit(this.router.url);
-  }
+    @Host() private baseComponent: GoCopyComponent
+  ) { }
 
   ngOnInit(): void {
     this.elementRef.nativeElement.classList.add('go-copy--card-header');
+    this.elementRef.nativeElement.title = 'Copy the url to this card';
+    this.baseComponent.text = window.location.href;
   }
 
 }

--- a/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.ts
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.ts
@@ -1,10 +1,12 @@
-import { Directive, ElementRef, Host, OnInit } from '@angular/core';
+import { Directive, ElementRef, Host, Input, OnInit } from '@angular/core';
 import { GoCopyComponent } from './go-copy.component';
 
 @Directive({
   selector: '[goCopyDocLink]'
 })
 export class GoCopyDocLinkDirective implements OnInit {
+
+  @Input() cardId: string;
 
   constructor(
     private elementRef: ElementRef,
@@ -13,8 +15,8 @@ export class GoCopyDocLinkDirective implements OnInit {
 
   ngOnInit(): void {
     this.elementRef.nativeElement.classList.add('go-copy--card-header');
-    this.elementRef.nativeElement.title = 'Copy the url to this card';
-    this.baseComponent.text = window.location.href;
+    this.elementRef.nativeElement.title = 'Copy the URL to this card';
+    this.baseComponent.text = `${window.location.href}/#${this.cardId}`;
   }
 
 }

--- a/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.ts
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy-doc-link.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, ElementRef, EventEmitter, OnInit, Output } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Directive({
+  selector: '[goCopyDocLink]'
+})
+export class GoCopyDocLinkDirective implements OnInit {
+
+  @Output() url: EventEmitter<string> = new EventEmitter<string>();
+
+  constructor(
+    private elementRef: ElementRef,
+    private router: Router
+  ) {
+    this.url.emit(this.router.url);
+  }
+
+  ngOnInit(): void {
+    this.elementRef.nativeElement.classList.add('go-copy--card-header');
+  }
+
+}

--- a/projects/go-lib/src/lib/components/go-copy/go-copy.component.scss
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy.component.scss
@@ -2,6 +2,12 @@
   position: relative;
 }
 
+:host.go-copy--card-header {
+  position: absolute;
+  margin-left: 0.75rem;
+  padding-top: 0.25rem;
+}
+
 .go-copy__textarea {
   left: 99999px;
   position: absolute;

--- a/projects/go-lib/src/lib/components/go-copy/go-copy.module.ts
+++ b/projects/go-lib/src/lib/components/go-copy/go-copy.module.ts
@@ -3,17 +3,20 @@ import { CommonModule } from '@angular/common';
 
 import { GoCopyComponent } from './go-copy.component';
 import { GoIconModule } from '../go-icon/go-icon.module';
+import { GoCopyDocLinkDirective } from './go-copy-doc-link.directive';
 
 @NgModule({
   declarations: [
-    GoCopyComponent
+    GoCopyComponent,
+    GoCopyDocLinkDirective
   ],
   imports: [
     CommonModule,
     GoIconModule
   ],
   exports: [
-    GoCopyComponent
+    GoCopyComponent,
+    GoCopyDocLinkDirective
   ]
 })
 

--- a/projects/go-lib/src/styles/_typography.scss
+++ b/projects/go-lib/src/styles/_typography.scss
@@ -32,6 +32,10 @@ strong {
   @extend %element--no-margin;
 }
 
+.go-heading--inline {
+  display: inline;
+}
+
 .go-link {
   @include transition(all);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #558 


## What is the new behavior?
This PR adds a directive which, when added to `go-copy` element within a `go-card-header`, enables it to function as a copy-permalink feature for our style-guide.

Example usage:
```html
  <go-card class="go-column go-column--100" id="default">
    <header go-card-header>
      <h2 class="go-heading-2 go-heading--inline">Default</h2>
      <go-copy cardId="default" goCopyDocLink></go-copy>
    </header>
    <div go-card-content>
      <!-- card contend here -->
    </div>
  </go-card>
```

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
