### PR TITLE
Use css only to manage padding for button

### DIFF
--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -19,7 +19,7 @@
     [disabled]="buttonDisabled || isProcessing"
     *ngIf="buttonIcon">
   </go-icon>
-  <span #buttonContent>
+  <span class="go-button__text">
     <ng-content></ng-content>
   </span>
 </button>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -3,6 +3,7 @@
   (click)="clicked()"
   [disabled]="buttonDisabled || isProcessing"
   [ngClass]="classObject"
+  [class.go-button--icon-only]="buttonContent.childNodes.length == 0"
   [type]="buttonType">
   <span class="go-button__loader"
         *ngIf="isProcessing"
@@ -19,7 +20,7 @@
     [disabled]="buttonDisabled || isProcessing"
     *ngIf="buttonIcon">
   </go-icon>
-  <span class="go-button__text">
+  <span #buttonContent class="go-button__text">
     <ng-content></ng-content>
   </span>
 </button>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -44,6 +44,10 @@
   display: inline-flex;
 }
 
+.go-button--icon-only {
+  padding: calc(.625rem - 1px) .625rem;
+}
+
 .go-button__icon ~ .go-button__text:not(:empty) {
   padding-left: .5rem;
 }

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -42,15 +42,10 @@
 
 .go-button__icon {
   display: inline-flex;
-  padding-right: .5rem;
 }
 
-.go-button--icon-only {
-  padding: calc(.625rem - 1px) .625rem;
-
-  .go-button__icon {
-    padding: 0;
-  }
+.go-button__icon ~ .go-button__text:not(:empty) {
+  padding-left: .5rem;
 }
 
 .go-button--loading {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
@@ -105,37 +105,6 @@ describe('GoButtonComponent', () => {
       expect(component.classObject['go-button--dark']).toBe(true);
       expect(component.classObject['go-button--loading']).toBe(true);
     });
-
-    it('returns an object that sets go-button--icon-only to false if buttonIcon is set and there is content in the button', () => {
-      component.buttonIcon = 'wizard';
-
-      component.ngOnChanges();
-
-      expect(component.classObject['go-button--icon-only']).toBeTruthy();
-
-      const goButtonTemplate: HTMLElement = fixture.nativeElement;
-      const buttonContentElement: HTMLButtonElement = goButtonTemplate.querySelector('button span:not(.go-button__loader)');
-      buttonContentElement.innerHTML = 'Harry Potter';
-      component.ngOnChanges();
-
-      expect(component.classObject['go-button--icon-only']).toBeFalsy();
-    });
-
-    it('returns an object that sets go-button--icon-only to true if buttonIcon is set and there is no content in the button', () => {
-      component.buttonIcon = 'wizard';
-      const goButtonTemplate: HTMLElement = fixture.nativeElement;
-      const buttonContentElement: HTMLButtonElement = goButtonTemplate.querySelector('button span:not(.go-button__loader)');
-      buttonContentElement.innerHTML = 'Harry Potter';
-
-      component.ngOnChanges();
-
-      expect(component.classObject['go-button--icon-only']).toBeFalsy();
-
-      buttonContentElement.innerHTML = null;
-      component.ngOnChanges();
-
-      expect(component.classObject['go-button--icon-only']).toBeTruthy();
-    });
   });
 
   describe('the template', () => {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -1,12 +1,10 @@
 import {
   Component,
-  ElementRef,
   EventEmitter,
   Input,
   OnChanges,
   OnInit,
   Output,
-  ViewChild
 } from '@angular/core';
 import { fadeTemplateAnimation } from '../../animations/fade.animation';
 
@@ -30,8 +28,6 @@ export class GoButtonComponent implements OnChanges, OnInit {
 
   @Output() handleClick: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-  @ViewChild('buttonContent') buttonContent: ElementRef;
-
   clicked(): void {
     this.handleClick.emit(this.isProcessing);
   }
@@ -53,7 +49,6 @@ export class GoButtonComponent implements OnChanges, OnInit {
     this.classObject = {
       'go-button--dark': this.useDarkTheme,
       'go-button--loading': this.isProcessing,
-      'go-button--icon-only': this.buttonIcon && !this.buttonContent.nativeElement.innerHTML
     };
 
     this.classObject['go-button--' + this.buttonVariant] = true;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #563 


## What is the new behavior?
This is a css only approach to fixing #563. The current solution introduced in #568 uses ViewChild to check if the DOM node has text, and is being accessed in `ngOnInit` which does not work in Angular 9.

## Does this PR introduce a breaking change?

<!-- Please check either yes or no using "x". -->

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
