### PR TITLE
Add ability to use content-projection within go-panels

### DIFF
--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
@@ -1,23 +1,36 @@
-<a class="go-panel"
-   target="_blank"
-   rel="noreferrer"
-   [ngClass]="panelClasses()"
-   [attr.href]="externalLink"
-   *ngIf="externalLink; else noLink"
-   (click)="closeActionSheet()">
+<!-- External Link -->
+<a
+  class="go-panel"
+  target="_blank"
+  rel="noreferrer"
+  [ngClass]="panelClasses()"
+  [attr.href]="externalLink"
+  *ngIf="externalLink; else noLink"
+  (click)="closeActionSheet()">
   <span class="go-panel__title">
     <span *ngIf="icon" class="go-panel__icon material-icons">{{icon}}</span>
     <span class="go-panel__title-text" [innerHtml]="panelContent"></span>
   </span>
 </a>
 
+<!-- No External Link -->
 <ng-template #noLink>
-  <button class="go-panel"
-          [ngClass]="panelClasses()"
-          (click)="handleAction()">
+  <button
+    class="go-panel"
+    [ngClass]="panelClasses()"
+    (click)="handleAction()">
     <span class="go-panel__title">
-      <span *ngIf="icon" class="go-panel__icon material-icons">{{icon}}</span>
-      <span class="go-panel__title-text" [innerHtml]="panelContent"></span>
+      <span
+        *ngIf="icon"
+        class="go-panel__icon material-icons">
+        {{icon}}
+      </span>
+      <span
+        *ngIf="panelContent"
+        class="go-panel__title-text"
+        [innerHtml]="panelContent">
+      </span>
+      <ng-content *ngIf="!panelContent"></ng-content>
     </span>
   </button>
 </ng-template>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.html
@@ -292,3 +292,52 @@
     </div>
   </go-card>
 </section>
+
+<go-card class="go-column go-column--100" id="content-projection">
+  <ng-container go-card-header>
+    <h2 class="go-heading-2 go-heading--no-wrap">Content Projection</h2>
+    <go-copy cardId="content-projection" goCopyCardLink></go-copy>
+  </ng-container>
+  <div go-card-content>
+    <div class="go-container">
+      <div class="go-column--100 go-column go-column--no-padding">
+        <p class="go-body-copy">
+          Content can be projected into a <code class="code-block--inline">go-panel</code>
+          to enable more complex structure and stylings. Content projection only works, however,
+          when nothing is passed to the <code class="code-block--inline">panelContent</code>
+          or <code class="code-block--inline">externalLink</code> inputs.
+        </p>
+      </div>
+      <div class="go-column go-column--50 go-column--no-padding">
+        <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+        <code [highlight]="contentProjectionHtml"></code>
+      </div>
+      <div class="go-column go-column--50 go-column--no-padding go-column--collapse">
+        <h4 class="go-heading-4 go-heading--underlined">View</h4>
+        <go-action-sheet>
+          <ng-container go-action-sheet__button>
+            <go-button>
+              Sheet With Content Projection
+            </go-button>
+          </ng-container>
+          <ng-container go-action-sheet-content>
+            <go-panel>
+              <ol class="go-ordered-list">
+                <li class="go-ordered-list__item">One</li>
+                <li class="go-ordered-list__item">Two</li>
+                <li class="go-ordered-list__item">Three</li>
+              </ol>
+            </go-panel>
+            <go-panel>
+              <ol class="go-ordered-list">
+                <li class="go-ordered-list__item">Four</li>
+                <li class="go-ordered-list__item">Five</li>
+                <li class="go-ordered-list__item">Six</li>
+              </ol>
+            </go-panel>
+          </ng-container>
+        </go-action-sheet>
+      </div>
+    </div>
+  </div>
+</go-card>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.ts
@@ -126,6 +126,32 @@ export class ActionSheetPanelDocsComponent {
   </go-action-sheet>
   `;
 
+  contentProjectionHtml: string = `
+    <go-action-sheet>
+      <ng-container go-action-sheet__button>
+        <go-button>
+          Sheet With Content Projection
+        </go-button>
+      </ng-container>
+      <ng-container go-action-sheet-content>
+        <go-panel>
+          <ol class="go-ordered-list">
+            <li class="go-ordered-list__item">One</li>
+            <li class="go-ordered-list__item">Two</li>
+            <li class="go-ordered-list__item">Three</li>
+          </ol>
+        </go-panel>
+        <go-panel>
+          <ol class="go-ordered-list">
+            <li class="go-ordered-list__item">Four</li>
+            <li class="go-ordered-list__item">Five</li>
+            <li class="go-ordered-list__item">Six</li>
+          </ol>
+        </go-panel>
+      </ng-container>
+    </go-action-sheet>
+  `;
+
   constructor(
     private toasterService: GoToasterService,
     private subNavService: SubNavService


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #618 

## What is the new behavior?
This enables html content to be projected into a `go-panel`, thus enabling styling to be applied to panel content.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
