### PR TITLE
Go select optgroup custom template

### DIFF
--- a/projects/go-lib/src/lib/components/go-select/go-select.component.html
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.html
@@ -35,6 +35,11 @@
       <ng-container *ngTemplateOutlet="goSelectSelectedOption; context: { $implicit: item }"></ng-container>
     </ng-template>
   </ng-container>
+  <ng-container *ngIf="goSelectOptionGroup">
+    <ng-template ng-optgroup-tmp let-item="item">
+      <ng-container *ngTemplateOutlet="goSelectOptionGroup; context: { $implicit: item }"></ng-container>
+    </ng-template>
+  </ng-container>
   <ng-container *ngIf="goSelectOption">
     <ng-template *ngIf="!goSelectSelectedOption" ng-label-tmp let-item="item">
       <ng-container *ngTemplateOutlet="goSelectOption; context: { $implicit: item }"></ng-container>

--- a/projects/go-lib/src/lib/components/go-select/go-select.component.ts
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.ts
@@ -34,6 +34,7 @@ export class GoSelectComponent implements OnInit {
   @Input() theme: 'light' | 'dark' = 'light';
 
   @ContentChild('goSelectOption', { static: false }) goSelectOption: TemplateRef<any>;
+  @ContentChild('goSelectOptionGroup', { static: false }) goSelectOptionGroup: TemplateRef<any>;
   @ContentChild('goSelectSelectedOption', { static: false }) goSelectSelectedOption: TemplateRef<any>;
 
   ngOnInit(): void {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.html
@@ -681,6 +681,56 @@
     </div>
   </go-card>
 
+  <go-card id="form-select-template-optgroup" class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Component Optgroup Label Template</h2>
+      <go-copy cardId="form-select-template-optgroup" goCopyCardLink></go-copy>
+    </ng-container>
+    <div class="go-container" go-card-content>
+
+      <div class="go-column go-column--100">
+        <p class="go-body-copy go-body-copy--no-margin">
+          When grouping, you may need to customize the optgroup label, for example when using the
+          <a
+            href="https://github.com/ng-select/ng-select/tree/0eec42cb8df68b1ca57d305f25a36a8e8618ce6e/src/demo/app/examples/group-children-example"
+            target="_blank">grouped children array</a> from ng-select where the label cannot be inferred.
+          You can add a custom template by adding a <code class="code-block--inline">ng-template</code> with a <code class="code-block--inline">#goSelectOptionGroup</code>
+        </p>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <div class="go-container">
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">View</h4>
+            <go-select
+              bindValue="value"
+              bindLabel="name"
+              [control]="select18"
+              [items]="groupedItemsArray"
+              groupBy="cars"
+              label="Select an Option">
+              <ng-template #goSelectOptionGroup let-item>
+                {{ item.manufacturer | uppercase }}
+              </ng-template>
+            </go-select>
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+            <code
+              [highlight]="select18Code"
+              class="code-block--no-bottom-margin">
+            </code>
+            <code
+              [highlight]="select18ComponentCode"
+              class="code-block--no-bottom-margin">
+            </code>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </go-card>
+
   <go-card id="form-select-template" class="go-column go-column--100">
     <ng-container go-card-header>
       <h2 class="go-heading-2 go-heading--no-wrap">Component Label Template</h2>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/select-docs/select-docs.component.ts
@@ -30,6 +30,22 @@ export class SelectDocsComponent implements OnInit {
     { value: 5, name: 'Silverado', manufacturer: 'Chevrolet' }
   ];
 
+  groupedItemsArray: any = [
+    {
+      manufacturer: 'Ford', cars: [
+        {value: 1, name: 'Mustang'},
+        {value: 2, name: 'Focus'}
+      ]
+    },
+    {
+      manufacturer: 'chevrolet',
+      cars: [
+        {value: 3, name: 'Camero'},
+        {value: 4, name: 'Corvette'},
+        {value: 5, name: 'Silverado'}]
+    }
+  ];
+
   select1: FormControl = new FormControl();
   select2: FormControl = new FormControl();
   select3: FormControl = new FormControl();
@@ -47,6 +63,7 @@ export class SelectDocsComponent implements OnInit {
   select15: FormControl = new FormControl();
   select16: FormControl = new FormControl();
   select17: FormControl = new FormControl();
+  select18: FormControl = new FormControl();
 
   hints: Array<string> = ['please select you favorite candy'];
 
@@ -314,6 +331,39 @@ export class SelectDocsComponent implements OnInit {
     [showSelectAll]="false"
     label="Favorite Candy">
   </go-select>
+  `;
+
+  select18Code: string = `
+  <go-select
+    bindValue="value"
+    [control]="select"
+    [items]="groupedItemsArray"
+    groupBy="cars"
+    label="Select an Option">
+    <ng-template #goSelectOptionGroup let-item>
+      {{ item.manufacturer | uppercase }}
+    </ng-template>
+  </go-select>
+  `;
+
+  select18ComponentCode: string = `
+  groupedItemsArray: any = [
+    {
+      manufacturer: 'Ford',
+      cars: [
+        {value: 1, name: 'Mustang'},
+        {value: 2, name: 'Focus'}
+      ]
+    },
+    {
+      manufacturer: 'chevrolet',
+      cars: [
+        {value: 3, name: 'Camero'},
+        {value: 4, name: 'Corvette'},
+        {value: 5, name: 'Silverado'}
+      ]
+    }
+  ]
   `;
 
   constructor(

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -121,14 +121,16 @@
 
               <div class="go-column go-column--50">
                 <go-select
-                  [items]="selectData"
+                  [items]="groupedSelectData"
                   [control]="selectControl"
                   bindValue="value"
                   bindLabel="name"
+                  groupBy="people"
                   [hints]="['Select an option here, whatever you want']"
                   [loading]="loadingSelectOptions"
                   placeholder="Select Box Placeholder"
                   label="Select Box Here">
+                  <ng-template #goSelectOptionGroup let-item>{{item.title}}</ng-template>
                 </go-select>
               </div>
               <div class="go-column go-column--50">

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import {Component, OnInit} from '@angular/core';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
 
 @Component({
   selector: 'app-test-page-3',
@@ -21,6 +21,28 @@ export class TestPage3Component implements OnInit {
   }, {
     value: 5,
     name: 'Snake'
+  }
+  ];
+
+  groupedSelectData: any = [{
+    title: 'Good', people: [{
+      value: 1,
+      name: 'Harry'
+    }, {
+      value: 2,
+      name: 'Hermione'
+    }, {
+      value: 3,
+      name: 'Ron'
+    }, ]
+  }, {
+    title: 'Evil', people: [{
+      value: 4,
+      name: 'Voldermort'
+    }, {
+      value: 5,
+      name: 'Snake'
+    }]
   }];
 
   fileControl: FormControl = new FormControl();
@@ -31,7 +53,7 @@ export class TestPage3Component implements OnInit {
       mangos: new FormControl(true),
       oranges: new FormControl(true)
     }),
-    name: new FormControl({ value: '', disabled: false }, Validators.required),
+    name: new FormControl({value: '', disabled: false}, Validators.required),
     notes: new FormControl(''),
     radio: new FormControl({value: '', disabled: false}),
     toggle: new FormControl(false),
@@ -43,10 +65,10 @@ export class TestPage3Component implements OnInit {
   loadingSelectOptions: boolean = true;
 
   otherThing: FormControl = new FormControl('test');
-  testOtherThing: FormControl = new FormControl({ value: 'Disabled Input', disabled: true });
+  testOtherThing: FormControl = new FormControl({value: 'Disabled Input', disabled: true});
   selectControl: FormControl = new FormControl();
-  otherSelectControl: FormControl = new FormControl({ value: 'Disabled Select', disabled: true });
-  validationSelectControl: FormControl = new FormControl({ value: 'Hermione', disabled: false });
+  otherSelectControl: FormControl = new FormControl({value: 'Disabled Select', disabled: true});
+  validationSelectControl: FormControl = new FormControl({value: 'Hermione', disabled: false});
   multiSelectControl: FormControl = new FormControl();
 
   constructor() { }
@@ -74,7 +96,7 @@ export class TestPage3Component implements OnInit {
           message: 'This is an invalid name.'
         }
       ],
-      notes: [{ message: 'test' }],
+      notes: [{message: 'test'}],
       radio: [{message: 'some test error'}],
       food: [{message: 'some test error'}],
       validationSelectControl: [{message: 'You need to select Ron.'}]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [ ] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ng-select allows passing a template to customize an optgroup label, but it does not work in the current structure of go-select.

## What is the new behavior?
This PR exposes that functionality through the go-select component.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Comments
I'm wondering if we would have been better off just shipping a custom template for ng-select instead of wrapping it up. I am sure issues like this will keep coming up for any feature in ng-select that will require our component to either be structured in a certain way or explicitly expose it like we needed to do here.