### PR TITLE
New bindings for radio button - Issue #639

### DIFF
--- a/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.html
+++ b/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.html
@@ -1,6 +1,6 @@
 <fieldset
   [disabled]="control.disabled"
-  [ngClass]="{ 'go-form__fieldset--error': control?.errors?.length, 'go-form__fieldset--dark': theme === 'dark', 'go-form__fieldset--disable': enableFieldset, 'go-form__fieldset go-form__fieldset--no-margin': enableFieldset === true }"
+  [ngClass]="{ 'go-form__fieldset--error': control?.errors?.length, 'go-form__fieldset--dark': theme === 'dark', 'go-form__fieldset--disable': enableFieldset, 'go-form__fieldset go-form__fieldset--no-margin': enableFieldset }"
 >
   <legend
     class="go-form__legend"

--- a/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.html
+++ b/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.html
@@ -1,6 +1,6 @@
 <fieldset
   [disabled]="control.disabled"
-  [ngClass]="{ 'go-form__fieldset--error': control?.errors?.length, 'go-form__fieldset--dark': theme === 'dark', 'go-form__fieldset--disable': fieldset, 'go-form__fieldset go-form__fieldset--no-margin': fieldset === true }"
+  [ngClass]="{ 'go-form__fieldset--error': control?.errors?.length, 'go-form__fieldset--dark': theme === 'dark', 'go-form__fieldset--disable': enableFieldset, 'go-form__fieldset go-form__fieldset--no-margin': enableFieldset === true }"
 >
   <legend
     class="go-form__legend"

--- a/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.html
+++ b/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.html
@@ -1,11 +1,11 @@
 <fieldset
-  class="go-form__fieldset go-form__fieldset--no-margin"
   [disabled]="control.disabled"
-  [ngClass]="{ 'go-form__fieldset--error': control?.errors?.length, 'go-form__fieldset--dark': theme === 'dark' }"
+  [ngClass]="{ 'go-form__fieldset--error': control?.errors?.length, 'go-form__fieldset--dark': theme === 'dark', 'go-form__fieldset--disable': fieldset, 'go-form__fieldset go-form__fieldset--no-margin': fieldset === true }"
 >
   <legend
     class="go-form__legend"
     [ngClass]="{ 'go-form__legend--dark': theme === 'dark' }"
+    *ngIf="enableLegend"
   >{{ legend }}</legend>
 
   <ng-content></ng-content>

--- a/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.spec.ts
@@ -85,6 +85,18 @@ describe('GoRadioGroupComponent', () => {
       expect(buttonTwo.name).toContain('Random-Name-');
     });
 
+    it('should have enableLegend set to true by default on page load', () => {
+      component.ngAfterContentChecked();
+
+      expect(component.enableLegend).toBeTruthy();
+    });
+
+    it('should have enableFieldset set to true by default on page load', () => {
+      component.ngAfterContentChecked();
+
+      expect(component.enableLegend).toBeTruthy();
+    });
+    
     it('should set a name on each child component when legend is NOT provided', () => {
       component.legend = undefined;
       component.ngAfterContentChecked();

--- a/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.spec.ts
@@ -94,7 +94,7 @@ describe('GoRadioGroupComponent', () => {
     it('should have enableFieldset set to true by default on page load', () => {
       component.ngAfterContentChecked();
 
-      expect(component.enableLegend).toBeTruthy();
+      expect(component.enableFieldset).toBeTruthy();
     });
     
     it('should set a name on each child component when legend is NOT provided', () => {

--- a/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.ts
+++ b/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.ts
@@ -12,6 +12,8 @@ export class GoRadioGroupComponent implements AfterContentChecked {
   @Input() control: FormControl;
   @Input() hints: string[];
   @Input() legend: string;
+  @Input() fieldset: boolean = true;
+  @Input() enableLegend: boolean = true;
   @Input() theme: 'light' | 'dark' = 'light';
 
   @ContentChildren(GoRadioButtonComponent) radioButtons: QueryList<GoRadioButtonComponent>;

--- a/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.ts
+++ b/projects/go-lib/src/lib/components/go-radio/go-radio-group.component.ts
@@ -12,7 +12,7 @@ export class GoRadioGroupComponent implements AfterContentChecked {
   @Input() control: FormControl;
   @Input() hints: string[];
   @Input() legend: string;
-  @Input() fieldset: boolean = true;
+  @Input() enableFieldset: boolean = true;
   @Input() enableLegend: boolean = true;
   @Input() theme: 'light' | 'dark' = 'light';
 

--- a/projects/go-lib/src/styles/_forms.scss
+++ b/projects/go-lib/src/styles/_forms.scss
@@ -22,6 +22,10 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   }
 }
 
+.go-form__fieldset--disable {
+  margin-bottom: $column-gutter--double;
+}
+
 .go-form--dark .go-form__fieldset,
 .go-form__fieldset--dark {
   &:disabled {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/radio-button-docs/radio-button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/radio-button-docs/radio-button-docs.component.html
@@ -78,7 +78,7 @@
         <p class="go-body-copy">
           Additionally, there are two more bindings: <code class="code-block--inline">enableFieldset</code> and
           <code class="code-block--inline">enableLegend</code>. You can use these to show/ hide the fieldset and (or)
-          the legend, respectively.
+          the legend, respectively. By default, both are set to <code class="code-block--inline">true</code>.
         </p>
         <p class="go-body-copy">
           Refer to the example below:

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/radio-button-docs/radio-button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/radio-button-docs/radio-button-docs.component.html
@@ -74,6 +74,47 @@
         </div>
       </div>
 
+      <div class="go-column go-column--100">
+        <p class="go-body-copy">
+          Additionally, there are two more bindings: <code class="code-block--inline">enableFieldset</code> and
+          <code class="code-block--inline">enableLegend</code>. You can use these to show/ hide the fieldset and (or)
+          the legend, respectively.
+        </p>
+        <p class="go-body-copy">
+          Refer to the example below:
+        </p>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <div class="go-container">
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">View</h4>
+            <go-radio-group
+              [enableFieldset]="false"
+              [enableLegend]="false"
+              [control]="radio5">
+              <div>
+                <go-radio-button
+                  label="Option 1"
+                  formValue="option1">
+                </go-radio-button>
+                <go-radio-button
+                  label="Option 2"
+                  formValue="option2">
+                </go-radio-button>
+              </div>
+            </go-radio-group>
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+            <code
+              [highlight]="radio5Ex"
+              class="code-block--no-bottom-margin">
+            </code>
+          </div>
+        </div>
+      </div>
+
     </div>
   </go-card>
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/radio-button-docs/radio-button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/radio-button-docs/radio-button-docs.component.html
@@ -74,47 +74,6 @@
         </div>
       </div>
 
-      <div class="go-column go-column--100">
-        <p class="go-body-copy">
-          Additionally, there are two more bindings: <code class="code-block--inline">enableFieldset</code> and
-          <code class="code-block--inline">enableLegend</code>. You can use these to show/ hide the fieldset and (or)
-          the legend, respectively. By default, both are set to <code class="code-block--inline">true</code>.
-        </p>
-        <p class="go-body-copy">
-          Refer to the example below:
-        </p>
-      </div>
-
-      <div class="go-column go-column--100 go-column--no-padding">
-        <div class="go-container">
-          <div class="go-column go-column--50">
-            <h4 class="go-heading-4 go-heading--underlined">View</h4>
-            <go-radio-group
-              [enableFieldset]="false"
-              [enableLegend]="false"
-              [control]="radio5">
-              <div>
-                <go-radio-button
-                  label="Option 1"
-                  formValue="option1">
-                </go-radio-button>
-                <go-radio-button
-                  label="Option 2"
-                  formValue="option2">
-                </go-radio-button>
-              </div>
-            </go-radio-group>
-          </div>
-          <div class="go-column go-column--50">
-            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
-            <code
-              [highlight]="radio5Ex"
-              class="code-block--no-bottom-margin">
-            </code>
-          </div>
-        </div>
-      </div>
-
     </div>
   </go-card>
 
@@ -235,10 +194,10 @@
     </div>
   </go-card>
 
-  <go-card id="form-radio-hints" class="go-column go-column--100">
+  <go-card id="form-radio-theme" class="go-column go-column--100">
     <ng-container go-card-header>
       <h2 class="go-heading-2 go-heading--no-wrap">Radio Theme</h2>
-      <go-copy cardId="form-radio-hints" goCopyCardLink></go-copy>
+      <go-copy cardId="form-radio-theme" goCopyCardLink></go-copy>
     </ng-container>
     <div class="go-container" go-card-content>
 
@@ -272,6 +231,54 @@
             <h4 class="go-heading-4 go-heading--underlined">Code</h4>
             <code
               [highlight]="radio4Ex"
+              class="code-block--no-bottom-margin">
+            </code>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </go-card>
+
+  <go-card id="form-radio-bindings" class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Additional Radio Bindings</h2>
+      <go-copy cardId="form-radio-bindings" goCopyCardLink></go-copy>
+    </ng-container>
+    <div class="go-container" go-card-content>
+
+      <div class="go-column go-column--100">
+        <p class="go-body-copy">
+          There are two more bindings: <code class="code-block--inline">enableFieldset</code> and
+          <code class="code-block--inline">enableLegend</code>. You can use these to show/ hide the fieldset and (or)
+          the legend, respectively. By default, both are set to <code class="code-block--inline">true</code>.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <div class="go-container">
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">View</h4>
+            <go-radio-group
+              [enableFieldset]="false"
+              [enableLegend]="false"
+              [control]="radio5">
+              <div>
+                <go-radio-button
+                  label="Option 1"
+                  formValue="option1">
+                </go-radio-button>
+                <go-radio-button
+                  label="Option 2"
+                  formValue="option2">
+                </go-radio-button>
+              </div>
+            </go-radio-group>
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+            <code
+              [highlight]="radio5Ex"
               class="code-block--no-bottom-margin">
             </code>
           </div>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/radio-button-docs/radio-button-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/radio-button-docs/radio-button-docs.component.ts
@@ -12,6 +12,7 @@ export class RadioButtonDocsComponent {
   radio2: FormControl = new FormControl('');
   radio3: FormControl = new FormControl('');
   radio4: FormControl = new FormControl('');
+  radio5: FormControl = new FormControl('');
 
   hints: Array<string> = ['this is a hint for the radio group'];
 
@@ -94,6 +95,20 @@ export class RadioButtonDocsComponent {
       </go-radio-button>
     </div>
     <div>
+      <go-radio-button label="Option 2" formValue="option2">
+      </go-radio-button>
+    </div>
+  </go-radio-group>
+  `;
+
+  radio5Ex: string = `
+  <go-radio-group
+    [enableFieldset]="false"
+    [enableLegend]="false"
+    [control]="radio5">
+    <div>
+      <go-radio-button label="Option 1" formValue="option1">
+      </go-radio-button>
       <go-radio-button label="Option 2" formValue="option2">
       </go-radio-button>
     </div>

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -58,21 +58,22 @@
               <div class="go-column go-column--50">
                 <go-radio-group
                   legend="Options"
+                  [fieldset]="true"
+                  [enableLegend]="false"
                   [hints]="['please select one']"
                   [control]="form.controls.radio"
                 >
-                  <div>
+                  
                     <go-radio-button
                       label="really cool radio option here"
                       formValue="option1"
                     ></go-radio-button>
-                  </div>
-                  <div>
+                  
                     <go-radio-button
                       label="Another really awesome option"
                       formValue="option2"
                     ></go-radio-button>
-                  </div>
+                  
                 </go-radio-group>
               </div>
 

--- a/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
+++ b/projects/go-tester/src/app/components/test-page-3/test-page-3.component.html
@@ -58,22 +58,23 @@
               <div class="go-column go-column--50">
                 <go-radio-group
                   legend="Options"
-                  [fieldset]="true"
-                  [enableLegend]="false"
+                  [enableFieldset]="true"
+                  [enableLegend]="true"
                   [hints]="['please select one']"
                   [control]="form.controls.radio"
                 >
-                  
+                  <div>
                     <go-radio-button
                       label="really cool radio option here"
                       formValue="option1"
                     ></go-radio-button>
-                  
+                  </div>
+                  <div>
                     <go-radio-button
                       label="Another really awesome option"
                       formValue="option2"
                     ></go-radio-button>
-                  
+                  </div>
                 </go-radio-group>
               </div>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
The current implementation of the radio button involves a legend and a fieldset, with no control over these two elements.

Resolves [639](https://github.com/mobi/goponents/issues/639)

## What is the new behavior?
With the introduction of two new bindings i.e. `enableLegend `and `enableFieldset`, the end user now has enough flexibility to control each of the two elements (i.e. legend and fieldset) individually.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
