### PR TITLE
Fix go-checkmark label position

### DIFF
--- a/projects/go-lib/src/styles/_forms.scss
+++ b/projects/go-lib/src/styles/_forms.scss
@@ -59,6 +59,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
 
 .go-form__label--checkbox-container {
   cursor: pointer;
+  line-height: 1.5;
   padding-left: 1.25rem;
   position: relative;
   user-select: none;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #654 

The label of the `go-checkbox` is positioned incorrectly:

![Screen Shot 2020-08-31 at 6 43 00 PM](https://user-images.githubusercontent.com/23343417/91775744-ced89900-ebb9-11ea-91e8-b9173c8bcfb7.png)

## What is the new behavior?
The label is now positioned correctly:

![Screen Shot 2020-08-31 at 6 43 17 PM](https://user-images.githubusercontent.com/23343417/91775754-d7c96a80-ebb9-11ea-82ac-f19608886e96.png)

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
