### PR TITLE
Removed loading test component from the first accordion titled 'Not Delayed'.

### DIFF
--- a/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
@@ -174,7 +174,6 @@
           <h4 class="go-heading-4 go-heading--underlined">View</h4>
           <go-accordion>
             <go-accordion-panel heading="Not Delayed">
-              <app-loading-test></app-loading-test>
             </go-accordion-panel>
             <go-accordion-panel heading="Delay Loading">
               <ng-template #panelContent>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
@@ -174,6 +174,7 @@
           <h4 class="go-heading-4 go-heading--underlined">View</h4>
           <go-accordion>
             <go-accordion-panel heading="Not Delayed">
+              This content loaded immediately.
             </go-accordion-panel>
             <go-accordion-panel heading="Delay Loading">
               <ng-template #panelContent>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [ ] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
When you go to the Accordion documentation, you land on the Overview sub route. Now click on the Panel option from right side of the screen, you'll notice a toast popping up at bottom right of the screen. This is unnecessary.

Resolves [662](https://github.com/mobi/goponents/issues/662)

## What is the new behavior?

The toast no more appears on page load when user clicks on 'Panel' option from Accordion documentation.


## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
