### PR TITLE
Change App Drawer Read Only Text 

### DIFF
--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
@@ -27,7 +27,7 @@
       </ng-container>
       <ng-container go-action-sheet-content>
         <go-panel [showHeader]="true">
-          <p class="go-side-nav__app-drawer--launch">{{ headerText }}</p>
+          <p class="go-side-nav__app-drawer--launch">{{ appDrawerHeader }}</p>
         </go-panel>
         <go-panel *ngFor="let appDrawerItem of (navAppDrawer?.appDrawerConfig || [])"
                   [icon]="appDrawerItem.icon"

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
@@ -27,7 +27,7 @@
       </ng-container>
       <ng-container go-action-sheet-content>
         <go-panel [showHeader]="true">
-          <p class="go-side-nav__app-drawer--switch-to">Switch to...</p>
+          <p class="go-side-nav__app-drawer--launch">Launch</p>
         </go-panel>
         <go-panel *ngFor="let appDrawerItem of (navAppDrawer?.appDrawerConfig || [])"
                   [icon]="appDrawerItem.icon"

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
@@ -27,7 +27,7 @@
       </ng-container>
       <ng-container go-action-sheet-content>
         <go-panel [showHeader]="true">
-          <p class="go-side-nav__app-drawer--launch">Launch</p>
+          <p class="go-side-nav__app-drawer--launch">{{ headerText }}</p>
         </go-panel>
         <go-panel *ngFor="let appDrawerItem of (navAppDrawer?.appDrawerConfig || [])"
                   [icon]="appDrawerItem.icon"

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.scss
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.scss
@@ -72,7 +72,7 @@
     padding-top: 3px;
   }
 
-  .go-side-nav__app-drawer--switch-to {
+  .go-side-nav__app-drawer--launch {
     color: $base-light-secondary;
     cursor: default;
     font-size: 0.6875rem;

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
@@ -16,6 +16,7 @@ import { GoSideNavService } from './go-side-nav.service';
 export class GoSideNavComponent implements OnInit {
   @Input() menuItems: Array<NavGroup | NavItem>;
   @Input() navAppDrawer: NavAppDrawer;
+  @Input() headerText: string = 'Launch';
 
 
   constructor (

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.ts
@@ -16,7 +16,7 @@ import { GoSideNavService } from './go-side-nav.service';
 export class GoSideNavComponent implements OnInit {
   @Input() menuItems: Array<NavGroup | NavItem>;
   @Input() navAppDrawer: NavAppDrawer;
-  @Input() headerText: string = 'Launch';
+  @Input() appDrawerHeader: string = 'Launch';
 
 
   constructor (

--- a/projects/go-style-guide/src/app/features/ui-kit/components/layout-docs/components/layout-nav/layout-nav.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/layout-docs/components/layout-nav/layout-nav.component.html
@@ -48,6 +48,13 @@
         </p>
       </div>
 
+      <div class="go-column go-column--100">
+        <h4 class="go-heading-4">appDrawerHeader</h4>
+        <p class="go-body-copy">
+          Optional <code class="code-block--inline">string</code> binding to set the header of the app drawer. This is defaulted to 'Launch'.
+        </p>
+      </div>
+
       <div class="go-column go-column--100 go-column--no-padding" id="important-notes">
         <h3 class="go-heading-3">Important Notes:</h3>
         <ol class="go-list go-list--ordered">

--- a/projects/go-style-guide/src/app/features/ui-kit/components/layout-docs/components/layout-nav/layout-nav.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/layout-docs/components/layout-nav/layout-nav.component.ts
@@ -11,6 +11,7 @@ export class LayoutNavComponent {
   componentBindings: string = `
   @Input() menuItems: Array<NavGroup | NavItem>;
   @Input() navAppDrawer: NavAppDrawer;
+  @Input() appDrawerHeader: string = 'Launch';
   `;
 
   bindings_menuItems: string = `


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [ ] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Currently the app drawer header reads 'Switch to...', and has specific hover state styles which are not as per DSM. 

Resolves [664](https://github.com/mobi/goponents/issues/664)

## What is the new behavior?
Appdrawer header must read 'Launch'. Also, styles for hover state of the header are as per DSM.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
