### PR TITLE
Accordion Panel Docs for Header Templates Cut Off

### DIFF
--- a/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/accordion-docs/components/accordion-panel-docs/accordion-panel-docs.component.html
@@ -231,7 +231,7 @@
       <div class="go-column go-column--50">
         <h4 class="go-heading-4 go-heading--underlined">Code</h4>
         <div class="go-container">
-          <div class="go-column go-column--50">
+          <div class="go-column go-column--100">
             <code [highlight]="headerTemplateExample"></code>
           </div>
         </div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Currently the code for the header template under accordion panel is cut off
<img width="886" alt="Screen Shot 2020-10-05 at 10 25 45 AM" src="https://user-images.githubusercontent.com/17074863/95092082-3b810f00-06f5-11eb-940a-433b9ddfc69f.png">

## What is the new behavior?
The code section for the Header Templates Panel Docs takes up the same amount of horizontal space as the title above it

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
