### PR TITLE
Add split-button functionality to go-button

### DIFF
--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -27,10 +27,9 @@
   </button>
 
   <div
-    class="dropdown"
     *ngIf="splitButtonOptions.length">
     <button
-      class="dropdown__button"
+      class="split-button"
       (click)="openDropdown()"
       [ngClass]="dropdownClassObject"
       [disabled]="buttonDisabled || isProcessing">

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -6,13 +6,15 @@
     [ngClass]="classObject"
     [class.go-button--icon-only]="buttonContent.childNodes.length == 0"
     [type]="buttonType">
-    <span class="go-button__loader"
-          *ngIf="isProcessing"
-          [ngClass]="loaderClassObject"
-          @fadeTemplate>
-      <go-loader [loaderType]="loaderType"
-                loaderSize="xsmall"
-                class="go-button__loader-container">
+    <span
+      class="go-button__loader"
+      *ngIf="isProcessing"
+      [ngClass]="loaderClassObject"
+      @fadeTemplate>
+      <go-loader
+        [loaderType]="loaderType"
+        loaderSize="xsmall"
+        class="go-button__loader-container">
       </go-loader>
     </span>
     <go-icon
@@ -21,7 +23,9 @@
       [disabled]="buttonDisabled || isProcessing"
       *ngIf="buttonIcon">
     </go-icon>
-    <span #buttonContent class="go-button__text">
+    <span
+      class="go-button__text"
+      #buttonContent>
       <ng-content></ng-content>
     </span>
   </button>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -26,13 +26,17 @@
     </span>
   </button>
 
-  <div class="dropdown" [ngClass]="dropdownClassObject">
-    <div class="dropdown__button" (click)="openDropdown()">
+  <div class="dropdown">
+    <button
+      class="dropdown__button"
+      (click)="openDropdown()"
+      [ngClass]="dropdownClassObject"
+      [disabled]="buttonDisabled || isProcessing">
       <go-icon
         icon="arrow_drop_down"
         iconModifier="light">
       </go-icon>
-    </div>
+    </button>
     <!-- <div
       class="dropdown__content-container"
       aria-expanded="true">

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -39,14 +39,18 @@
         [disabled]="buttonDisabled || isProcessing">
       </go-icon>
     </button>
-    <!-- <div
-      class="dropdown__content-container"
+    <div
+      class="split-button__content-container"
       aria-expanded="true">
-      <div class="dropdown__content">
-        <div class="dropdown__scroll-container">
-          <ng-content select="[dropdown-content]"></ng-content>
+      <div class="split-button__content">
+        <div class="split-button__scroll-container">
+          <div
+            class="split-button__option"
+            *ngFor="let option of splitButtonOptions">
+            {{ option.label }}
+          </div>
         </div>
       </div>
-    </div> -->
+    </div>
   </div>
 </div>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -34,7 +34,8 @@
       [disabled]="buttonDisabled || isProcessing">
       <go-icon
         icon="arrow_drop_down"
-        iconModifier="light">
+        [iconModifier]="splitButtonIconModifier"
+        [disabled]="buttonDisabled || isProcessing">
       </go-icon>
     </button>
     <!-- <div

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -45,7 +45,8 @@
       aria-expanded="true">
       <div
         class="split-button__option"
-        *ngFor="let option of splitButtonOptions">
+        *ngFor="let option of splitButtonOptions"
+        (click)="splitButtonOptionSelected(option.value)">
         {{ option.label }}
       </div>
     </div>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -50,7 +50,7 @@
       <div
         class="split-button__menu-option"
         *ngFor="let option of splitButtonOptions"
-        (click)="splitButtonOptionSelected(option.value)">
+        (click)="splitButtonOptionSelected(option.action)">
         {{ option.label }}
       </div>
     </div>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -26,11 +26,10 @@
     </span>
   </button>
 
-  <div
-    *ngIf="splitButtonOptions.length">
+  <div *ngIf="splitButtonOptions.length">
     <button
       class="split-button"
-      (click)="openDropdown()"
+      (click)="toggleSplitButtonMenu()"
       [ngClass]="dropdownClassObject"
       [disabled]="buttonDisabled || isProcessing">
       <go-icon
@@ -39,17 +38,15 @@
         [disabled]="buttonDisabled || isProcessing">
       </go-icon>
     </button>
+
     <div
-      class="split-button__content-container"
+      class="split-button__menu"
+      [ngClass]="{'split-button__menu--active': showSplitButtonMenu}"
       aria-expanded="true">
-      <div class="split-button__content">
-        <div class="split-button__scroll-container">
-          <div
-            class="split-button__option"
-            *ngFor="let option of splitButtonOptions">
-            {{ option.label }}
-          </div>
-        </div>
+      <div
+        class="split-button__option"
+        *ngFor="let option of splitButtonOptions">
+        {{ option.label }}
       </div>
     </div>
   </div>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -23,4 +23,23 @@
   <span #buttonContent class="go-button__text">
     <ng-content></ng-content>
   </span>
+
+  <div class="split-button">
+    <div class="split-button__dropdown-button" (click)="openDropdown()">
+      <go-icon
+        icon="arrow_drop_down"
+        iconModifier="light">
+      </go-icon>
+    </div>
+
+    <!-- <div
+      class="split-button__content-container"
+      aria-expanded="true">
+      <div class="split-button__content">
+        <div class="split-button__scroll-container">
+          <ng-content select="[split-button-content]"></ng-content>
+        </div>
+      </div>
+    </div> -->
+  </div>
 </button>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -37,7 +37,7 @@
       [ngClass]="splitButtonClassObject"
       [disabled]="buttonDisabled || isProcessing">
       <go-icon
-        icon="arrow_drop_down"
+        [icon]="showSplitButtonMenu ? 'arrow_drop_up' : 'arrow_drop_down'"
         [iconModifier]="splitButtonIconModifier"
         [disabled]="buttonDisabled || isProcessing">
       </go-icon>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -30,7 +30,7 @@
     <button
       class="split-button"
       (click)="toggleSplitButtonMenu()"
-      [ngClass]="dropdownClassObject"
+      [ngClass]="splitButtonClassObject"
       [disabled]="buttonDisabled || isProcessing">
       <go-icon
         icon="arrow_drop_down"

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -46,7 +46,7 @@
     <div
       class="split-button__menu"
       [ngClass]="{'split-button__menu--active': showSplitButtonMenu}"
-      aria-expanded="true">
+      [attr.aria-expanded]="showSplitButtonMenu">
       <div
         class="split-button__menu-option"
         *ngFor="let option of splitButtonOptions"

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -1,45 +1,46 @@
-<button
-  class="go-button"
-  (click)="clicked()"
-  [disabled]="buttonDisabled || isProcessing"
-  [ngClass]="classObject"
-  [class.go-button--icon-only]="buttonContent.childNodes.length == 0"
-  [type]="buttonType">
-  <span class="go-button__loader"
-        *ngIf="isProcessing"
-        [ngClass]="loaderClassObject"
-        @fadeTemplate>
-    <go-loader [loaderType]="loaderType"
-               loaderSize="xsmall"
-               class="go-button__loader-container">
-    </go-loader>
-  </span>
-  <go-icon
-    [icon]="buttonIcon"
-    class="go-button__icon"
+<div class="go-button-container">
+  <button
+    class="go-button"
+    (click)="clicked()"
     [disabled]="buttonDisabled || isProcessing"
-    *ngIf="buttonIcon">
-  </go-icon>
-  <span #buttonContent class="go-button__text">
-    <ng-content></ng-content>
-  </span>
+    [ngClass]="classObject"
+    [class.go-button--icon-only]="buttonContent.childNodes.length == 0"
+    [type]="buttonType">
+    <span class="go-button__loader"
+          *ngIf="isProcessing"
+          [ngClass]="loaderClassObject"
+          @fadeTemplate>
+      <go-loader [loaderType]="loaderType"
+                loaderSize="xsmall"
+                class="go-button__loader-container">
+      </go-loader>
+    </span>
+    <go-icon
+      [icon]="buttonIcon"
+      class="go-button__icon"
+      [disabled]="buttonDisabled || isProcessing"
+      *ngIf="buttonIcon">
+    </go-icon>
+    <span #buttonContent class="go-button__text">
+      <ng-content></ng-content>
+    </span>
+  </button>
 
-  <div class="split-button">
-    <div class="split-button__dropdown-button" (click)="openDropdown()">
+  <div class="dropdown" [ngClass]="dropdownClassObject">
+    <div class="dropdown__button" (click)="openDropdown()">
       <go-icon
         icon="arrow_drop_down"
         iconModifier="light">
       </go-icon>
     </div>
-
     <!-- <div
-      class="split-button__content-container"
+      class="dropdown__content-container"
       aria-expanded="true">
-      <div class="split-button__content">
-        <div class="split-button__scroll-container">
-          <ng-content select="[split-button-content]"></ng-content>
+      <div class="dropdown__content">
+        <div class="dropdown__scroll-container">
+          <ng-content select="[dropdown-content]"></ng-content>
         </div>
       </div>
     </div> -->
   </div>
-</button>
+</div>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -44,7 +44,7 @@
       [ngClass]="{'split-button__menu--active': showSplitButtonMenu}"
       aria-expanded="true">
       <div
-        class="split-button__option"
+        class="split-button__menu-option"
         *ngFor="let option of splitButtonOptions"
         (click)="splitButtonOptionSelected(option.value)">
         {{ option.label }}

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -30,7 +30,7 @@
     </span>
   </button>
 
-  <div *ngIf="isSplitButton()">
+  <ng-container *ngIf="isSplitButton()">
     <button
       class="split-button"
       (click)="toggleSplitButtonMenu()"
@@ -54,5 +54,5 @@
         {{ option.label }}
       </div>
     </div>
-  </div>
+  </ng-container>
 </div>

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -26,7 +26,7 @@
     </span>
   </button>
 
-  <div *ngIf="splitButtonOptions.length">
+  <div *ngIf="isSplitButton()">
     <button
       class="split-button"
       (click)="toggleSplitButtonMenu()"

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.html
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.html
@@ -26,7 +26,9 @@
     </span>
   </button>
 
-  <div class="dropdown">
+  <div
+    class="dropdown"
+    *ngIf="splitButtonOptions.length">
     <button
       class="dropdown__button"
       (click)="openDropdown()"

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -16,6 +16,7 @@
 }
 
 .go-button-container {
+  display: inline-flex;
   position: relative;
 }
 
@@ -369,10 +370,6 @@
 
 // Split Button
 //=========================
-.go-button-container {
-  display: inline-flex;
-}
-
 .go-button--split {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
@@ -404,12 +401,11 @@
   cursor: pointer;
   align-items: center;
   display: flex;
+  font-size: 0.875rem;
   justify-content: center;
   height: 2rem;
   outline: none;
   padding: 0;
-  position: relative;
-  right: 0;
   width: 2rem;
   z-index: 2;
 
@@ -421,14 +417,6 @@
 
   &:disabled:not(.go-button--loading) {
     cursor: not-allowed;
-  }
-
-  &.go-button--primary:hover,
-  &.go-button--secondary:hover,
-  &.go-button--tertiary:hover,
-  &.go-button--negative:hover,
-  &.go-button--neutral:hover {
-    border-left: none;
   }
 }
 
@@ -451,7 +439,7 @@
   }
 }
 
-.split-button__option {
+.split-button__menu-option {
   @include transition;
 
   color: $theme-light-color;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -307,11 +307,21 @@
 .go-button--split {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+  border-right: none;
+
+  &.go-button--primary:hover,
+  &.go-button--secondary:hover,
+  &.go-button--tertiary:hover,
+  &.go-button--negative:hover,
+  &.go-button--neutral:hover {
+    border-right: none;
+  }
 }
 
 .dropdown__button {
   border-bottom-right-radius: $global-radius;
   border-top-right-radius: $global-radius;
+  border-left: none;
   box-sizing: content-box;
   cursor: pointer;
   align-items: center;
@@ -326,6 +336,14 @@
 
   &:disabled:not(.go-button--loading) {
     cursor: not-allowed;
+  }
+
+  &.go-button--primary:hover,
+  &.go-button--secondary:hover,
+  &.go-button--tertiary:hover,
+  &.go-button--negative:hover,
+  &.go-button--neutral:hover {
+    border-left: none;
   }
 
   // TODO: Check with UX if this is really what's intended

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -373,6 +373,11 @@
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   border-right: none;
+  z-index: 2;
+
+  &:hover {
+    z-index: 1;
+  }
 
   &:disabled:not(.go-button--loading) {
     border-right: none;
@@ -407,6 +412,11 @@
   position: relative;
   right: 0;
   width: 2rem;
+  z-index: 2;
+
+  &:hover {
+    z-index: 1;
+  }
 
   &:disabled:not(.go-button--loading) {
     cursor: not-allowed;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -382,6 +382,7 @@
   &:hover,
   &:focus,
   &:active {
+    border-right: none;
     z-index: 1;
   }
 
@@ -392,14 +393,6 @@
     &:focus {
       border-right: none;
     }
-  }
-
-  &.go-button--primary:hover,
-  &.go-button--secondary:hover,
-  &.go-button--tertiary:hover,
-  &.go-button--negative:hover,
-  &.go-button--neutral:hover {
-    border-right: none;
   }
 }
 

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -433,6 +433,7 @@ $button-shadow-secondary: 0 0 0 3px transparentize($base-light-tertiary, .75);
   opacity: 0;
   position: absolute;
   right: 0;
+  top: calc(2rem + 2px);
   visibility: hidden;
   z-index: 300;
 

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -94,7 +94,7 @@
   }
 }
 
-.dropdown__button--primary {
+.split-button--primary {
   background: $ui-color-primary-hover;
   border: 1px solid $ui-color-primary-hover;
   border-left: none;
@@ -182,7 +182,7 @@
   }
 }
 
-.dropdown__button--secondary {
+.split-button--secondary {
   background: $theme-light-bg-hover;
   border: 1px solid lighten($base-light-secondary, 10%);
   color: $theme-light-color;
@@ -397,7 +397,7 @@
   }
 }
 
-.dropdown__button {
+.split-button {
   border-bottom-right-radius: $global-radius;
   border-top-right-radius: $global-radius;
   border-left: none;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -1,6 +1,8 @@
 @import '../../../styles/variables';
 @import '../../../styles/mixins';
 
+$button-shadow-secondary: 0 0 0 3px transparentize($base-light-tertiary, .75);
+
 @mixin disabled-states($bg, $color, $color-opacity: .7) {
   @if ($color == 'light') {
     @if ($color-opacity == .7) {
@@ -174,7 +176,7 @@
   &:focus,
   &:active {
     border: 1px solid lighten($base-light-secondary, 10%);
-    box-shadow: 0 0 0 3px transparentize($base-light-tertiary, .75);
+    box-shadow: $button-shadow-secondary;
   }
 
   &:disabled:not(.go-button--loading) {
@@ -196,13 +198,13 @@
   &:focus {
     background: $theme-light-bg-active;
     border-left: none;
-    box-shadow: 0 0 0 3px transparentize($base-light-tertiary, .75);
+    box-shadow: $button-shadow-secondary;
   }
 
   &:active {
     background: darken($theme-light-bg, 10%);
     border-left: none;
-    box-shadow: 0 0 0 3px transparentize($base-light-tertiary, .75);
+    box-shadow: $button-shadow-secondary;
   }
 
   &:disabled:not(.go-button--loading) {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -127,7 +127,8 @@
   }
 }
 
-.go-button--secondary {
+.go-button--secondary,
+.dropdown__button--secondary {
   border: 1px solid lighten($base-light-secondary, 10%);
 }
 
@@ -164,6 +165,37 @@
   }
 }
 
+.dropdown__button--secondary {
+  background: $theme-light-bg-hover;
+  color: $theme-light-color;
+
+  &:hover,
+  &:focus {
+    background: $theme-light-bg-active;
+    border-left: none;
+  }
+
+  &:active {
+    background: darken($theme-light-bg, 10%);
+    border-left: none;
+  }
+
+  &:disabled:not(.go-button--loading) {
+    // @include disabled-states($theme-light-bg, 'dark');
+    // border: 1px solid rgba($theme-light-bg, 0);
+    border-left: none;
+
+    &:hover,
+    &:focus {
+      // @include disabled-states($theme-light-bg, 'dark');
+      // border: 1px solid rgba($theme-light-bg, 0);
+      background: $theme-light-bg-hover;
+      border-left: none;
+      box-shadow: none;
+    }
+  }
+}
+
 .go-button--secondary {
   &:hover,
   &:focus,
@@ -178,6 +210,27 @@
     &:hover,
     &:focus {
       border: 1px solid $theme-light-bg-active;
+    }
+  }
+}
+
+.dropdown__button--secondary {
+  &:hover,
+  &:focus,
+  &:active {
+    border: 1px solid lighten($base-light-secondary, 10%);
+    box-shadow: 0 0 0 3px transparentize($base-light-tertiary, .75);
+    border-left: none;
+  }
+
+  &:disabled:not(.go-button--loading) {
+    border: 1px solid $theme-light-bg-active;
+    border-left: none;
+
+    &:hover,
+    &:focus {
+      border: 1px solid $theme-light-bg-active;
+      border-left: none;
     }
   }
 }

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -127,8 +127,7 @@
   }
 }
 
-.go-button--secondary,
-.dropdown__button--secondary {
+.go-button--secondary {
   border: 1px solid lighten($base-light-secondary, 10%);
 }
 
@@ -165,37 +164,6 @@
   }
 }
 
-.dropdown__button--secondary {
-  background: $theme-light-bg-hover;
-  color: $theme-light-color;
-
-  &:hover,
-  &:focus {
-    background: $theme-light-bg-active;
-    border-left: none;
-  }
-
-  &:active {
-    background: darken($theme-light-bg, 10%);
-    border-left: none;
-  }
-
-  &:disabled:not(.go-button--loading) {
-    // @include disabled-states($theme-light-bg, 'dark');
-    // border: 1px solid rgba($theme-light-bg, 0);
-    border-left: none;
-
-    &:hover,
-    &:focus {
-      // @include disabled-states($theme-light-bg, 'dark');
-      // border: 1px solid rgba($theme-light-bg, 0);
-      background: $theme-light-bg-hover;
-      border-left: none;
-      box-shadow: none;
-    }
-  }
-}
-
 .go-button--secondary {
   &:hover,
   &:focus,
@@ -215,12 +183,21 @@
 }
 
 .dropdown__button--secondary {
+  background: $theme-light-bg-hover;
+  border: 1px solid lighten($base-light-secondary, 10%);
+  color: $theme-light-color;
+
   &:hover,
-  &:focus,
-  &:active {
-    border: 1px solid lighten($base-light-secondary, 10%);
-    box-shadow: 0 0 0 3px transparentize($base-light-tertiary, .75);
+  &:focus {
+    background: $theme-light-bg-active;
     border-left: none;
+    box-shadow: 0 0 0 3px transparentize($base-light-tertiary, .75);
+  }
+
+  &:active {
+    background: darken($theme-light-bg, 10%);
+    border-left: none;
+    box-shadow: 0 0 0 3px transparentize($base-light-tertiary, .75);
   }
 
   &:disabled:not(.go-button--loading) {
@@ -229,8 +206,10 @@
 
     &:hover,
     &:focus {
+      background: $theme-light-bg-hover;
       border: 1px solid $theme-light-bg-active;
       border-left: none;
+      box-shadow: none;
     }
   }
 }
@@ -394,6 +373,15 @@
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   border-right: none;
+
+  &:disabled:not(.go-button--loading) {
+    border-right: none;
+
+    &:hover,
+    &:focus {
+      border-right: none;
+    }
+  }
 
   &.go-button--primary:hover,
   &.go-button--secondary:hover,

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -94,6 +94,39 @@
   }
 }
 
+.dropdown__button--primary {
+  background: $ui-color-primary-hover;
+  border: 1px solid $ui-color-primary-hover;
+  border-left: none;
+
+  &:hover,
+  &:focus {
+    background: $ui-color-primary-active;
+    border: 1px solid $ui-color-primary-active;
+    border-left: none;
+    box-shadow: $form-shadow-active;
+  }
+
+  &:active {
+    background: darken($ui-color-primary, 10%);
+    border: 1px solid darken($ui-color-primary, 10%);
+    border-left: none;
+    box-shadow: $form-shadow-active;
+  }
+
+  &:disabled:not(.go-button--loading) {
+    @include disabled-states($ui-color-primary, 'light');
+    border: 1px solid rgba($ui-color-primary, 0);
+
+    &:hover,
+    &:focus {
+      @include disabled-states($ui-color-primary, 'light');
+      border: 1px solid rgba($ui-color-primary, 0);
+      box-shadow: none;
+    }
+  }
+}
+
 .go-button--secondary {
   border: 1px solid lighten($base-light-secondary, 10%);
 }
@@ -347,17 +380,17 @@
   }
 
   // TODO: Check with UX if this is really what's intended
-  &:before {
-    background: rgba(0,0,0,.1);
-    bottom: 0;
-    content: " ";
-    display: block;
-    height: 2rem;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    width: 2rem;
-    z-index: 10;
-  }
+  // &:before {
+  //   background: rgba(0,0,0,.1);
+  //   bottom: 0;
+  //   content: " ";
+  //   display: block;
+  //   height: 2rem;
+  //   left: 0;
+  //   position: absolute;
+  //   right: 0;
+  //   top: 0;
+  //   width: 2rem;
+  //   z-index: 10;
+  // }
 }

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -442,14 +442,15 @@
   border: 1px solid $base-light-tertiary;
   border-radius: $global-radius;
   box-shadow: $global-box-shadow--small;
+  opacity: 0;
   position: absolute;
   right: 0;
   visibility: hidden;
-  opacity: 0;
+  z-index: 300;
 
   &.split-button__menu--active {
-    visibility: visible;
     opacity: 1;
+    visibility: visible;
   }
 }
 

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -297,3 +297,20 @@
     margin-right: 0;
   }
 }
+
+// Split Button
+//=========================
+.go-button--split {
+  padding-right: 2rem + $column-gutter;
+}
+
+.split-button {
+  position: absolute;
+  height: 2rem;
+  width: 2rem;
+  right: 0;
+  background: rgba(0,0,0,.1);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -45,7 +45,7 @@
 }
 
 .go-button--icon-only {
-  padding: calc(.625rem - 1px) .625rem;
+  padding: calc(.625rem - 2px) .625rem;
 }
 
 .go-button__icon ~ .go-button__text:not(:empty) {
@@ -300,17 +300,40 @@
 
 // Split Button
 //=========================
-.go-button--split {
-  padding-right: 2rem + $column-gutter;
+.go-button-container {
+  display: inline-flex;
 }
 
-.split-button {
-  position: absolute;
-  height: 2rem;
-  width: 2rem;
-  right: 0;
-  background: rgba(0,0,0,.1);
+.go-button--split {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.dropdown {
+  border-bottom-right-radius: $global-radius;
+  border-top-right-radius: $global-radius;
+  box-sizing: content-box;
+  cursor: pointer;
+  align-items: center;
   display: flex;
   justify-content: center;
-  align-items: center;
+  height: 2rem;
+  position: relative;
+  right: 0;
+  width: 2rem;
+
+  // TODO: Check with UX if this is really what's intended
+  &:before {
+    background: rgba(0,0,0,.1);
+    bottom: 0;
+    content: " ";
+    display: block;
+    height: 2rem;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 2rem;
+    z-index: 10;
+  }
 }

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -15,6 +15,10 @@
   background: rgba($bg, .4);
 }
 
+.go-button-container {
+  position: relative;
+}
+
 .go-button {
   @include transition(all);
 
@@ -444,4 +448,33 @@
   //   width: 2rem;
   //   z-index: 10;
   // }
+}
+
+.split-button__content-container {
+  @include transition;
+
+  background: $theme-light-bg;
+  border: 1px solid $base-light-tertiary;
+  border-radius: $global-radius;
+  box-shadow: $global-box-shadow--small;
+  position: absolute;
+  right: 0;
+}
+
+.split-button__option {
+  color: $theme-light-color;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: normal;
+  max-width: 20rem;
+  padding: 0.75rem;
+  white-space: nowrap;
+
+  &:hover {
+    background: $theme-light-bg-active;
+  }
+
+  &:active {
+    background: $theme-light-bg-hover;
+  }
 }

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -433,24 +433,9 @@
   &.go-button--neutral:hover {
     border-left: none;
   }
-
-  // TODO: Check with UX if this is really what's intended
-  // &:before {
-  //   background: rgba(0,0,0,.1);
-  //   bottom: 0;
-  //   content: " ";
-  //   display: block;
-  //   height: 2rem;
-  //   left: 0;
-  //   position: absolute;
-  //   right: 0;
-  //   top: 0;
-  //   width: 2rem;
-  //   z-index: 10;
-  // }
 }
 
-.split-button__content-container {
+.split-button__menu {
   @include transition;
 
   background: $theme-light-bg;
@@ -459,9 +444,18 @@
   box-shadow: $global-box-shadow--small;
   position: absolute;
   right: 0;
+  visibility: hidden;
+  opacity: 0;
+
+  &.split-button__menu--active {
+    visibility: visible;
+    opacity: 1;
+  }
 }
 
 .split-button__option {
+  @include transition;
+
   color: $theme-light-color;
   cursor: pointer;
   font-size: 0.875rem;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -101,39 +101,6 @@ $button-shadow-secondary: 0 0 0 3px transparentize($base-light-tertiary, .75);
   }
 }
 
-.split-button--primary {
-  background: $ui-color-primary-hover;
-  border: 1px solid $ui-color-primary-hover;
-  border-left: none;
-
-  &:hover,
-  &:focus {
-    background: $ui-color-primary-active;
-    border: 1px solid $ui-color-primary-active;
-    border-left: none;
-    box-shadow: $form-shadow-active;
-  }
-
-  &:active {
-    background: darken($ui-color-primary, 10%);
-    border: 1px solid darken($ui-color-primary, 10%);
-    border-left: none;
-    box-shadow: $form-shadow-active;
-  }
-
-  &:disabled:not(.go-button--loading) {
-    @include disabled-states($ui-color-primary, 'light');
-    border: 1px solid rgba($ui-color-primary, 0);
-
-    &:hover,
-    &:focus {
-      @include disabled-states($ui-color-primary, 'light');
-      border: 1px solid rgba($ui-color-primary, 0);
-      box-shadow: none;
-    }
-  }
-}
-
 .go-button--secondary {
   border: 1px solid lighten($base-light-secondary, 10%);
 }
@@ -185,38 +152,6 @@ $button-shadow-secondary: 0 0 0 3px transparentize($base-light-tertiary, .75);
     &:hover,
     &:focus {
       border: 1px solid $theme-light-bg-active;
-    }
-  }
-}
-
-.split-button--secondary {
-  background: $theme-light-bg-hover;
-  border: 1px solid lighten($base-light-secondary, 10%);
-  color: $theme-light-color;
-
-  &:hover,
-  &:focus {
-    background: $theme-light-bg-active;
-    border-left: none;
-    box-shadow: $button-shadow-secondary;
-  }
-
-  &:active {
-    background: darken($theme-light-bg, 10%);
-    border-left: none;
-    box-shadow: $button-shadow-secondary;
-  }
-
-  &:disabled:not(.go-button--loading) {
-    border: 1px solid $theme-light-bg-active;
-    border-left: none;
-
-    &:hover,
-    &:focus {
-      background: $theme-light-bg-hover;
-      border: 1px solid $theme-light-bg-active;
-      border-left: none;
-      box-shadow: none;
     }
   }
 }
@@ -419,6 +354,72 @@ $button-shadow-secondary: 0 0 0 3px transparentize($base-light-tertiary, .75);
 
   &:disabled:not(.go-button--loading) {
     cursor: not-allowed;
+  }
+}
+
+.split-button--primary {
+  background: $ui-color-primary-hover;
+  border: 1px solid $ui-color-primary-hover;
+  border-left: none;
+
+  &:hover,
+  &:focus {
+    background: $ui-color-primary-active;
+    border: 1px solid $ui-color-primary-active;
+    border-left: none;
+    box-shadow: $form-shadow-active;
+  }
+
+  &:active {
+    background: darken($ui-color-primary, 10%);
+    border: 1px solid darken($ui-color-primary, 10%);
+    border-left: none;
+    box-shadow: $form-shadow-active;
+  }
+
+  &:disabled:not(.go-button--loading) {
+    @include disabled-states($ui-color-primary, 'light');
+    border: 1px solid rgba($ui-color-primary, 0);
+
+    &:hover,
+    &:focus {
+      @include disabled-states($ui-color-primary, 'light');
+      border: 1px solid rgba($ui-color-primary, 0);
+      box-shadow: none;
+    }
+  }
+}
+
+.split-button--secondary {
+  background: $theme-light-bg-hover;
+  border: 1px solid lighten($base-light-secondary, 10%);
+  border-left: none;
+  color: $theme-light-color;
+
+  &:hover,
+  &:focus {
+    background: $theme-light-bg-active;
+    border-left: none;
+    box-shadow: $button-shadow-secondary;
+  }
+
+  &:active {
+    background: darken($theme-light-bg, 10%);
+    border-left: none;
+    box-shadow: $button-shadow-secondary;
+  }
+
+  &:disabled:not(.go-button--loading) {
+    border: 1px solid $theme-light-bg-active;
+    border-left: none;
+
+    &:hover,
+    &:focus {
+      background: $theme-light-bg-hover;
+      border: 1px solid $theme-light-bg-active;
+      border-left: none;
+      box-shadow: none;
+    }
   }
 }
 

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -309,7 +309,7 @@
   border-bottom-right-radius: 0;
 }
 
-.dropdown {
+.dropdown__button {
   border-bottom-right-radius: $global-radius;
   border-top-right-radius: $global-radius;
   box-sizing: content-box;
@@ -318,9 +318,15 @@
   display: flex;
   justify-content: center;
   height: 2rem;
+  outline: none;
+  padding: 0;
   position: relative;
   right: 0;
   width: 2rem;
+
+  &:disabled:not(.go-button--loading) {
+    cursor: not-allowed;
+  }
 
   // TODO: Check with UX if this is really what's intended
   &:before {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -446,9 +446,8 @@
   cursor: pointer;
   font-size: 0.875rem;
   font-weight: normal;
-  max-width: 20rem;
+  max-width: 10rem;
   padding: 0.75rem;
-  white-space: nowrap;
 
   &:hover {
     background: $theme-light-bg-active;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -379,7 +379,9 @@
   border-right: none;
   z-index: 2;
 
-  &:hover {
+  &:hover,
+  &:focus,
+  &:active {
     z-index: 1;
   }
 
@@ -418,7 +420,9 @@
   width: 2rem;
   z-index: 2;
 
-  &:hover {
+  &:hover,
+  &:focus,
+  &:active {
     z-index: 1;
   }
 

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
@@ -1,10 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { GoButtonComponent } from './go-button.component';
-import { GoIconModule } from '../go-icon/go-icon.module';
-import { GoLoaderModule } from '../go-loader/go-loader.module';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { GoIconModule } from '../go-icon/go-icon.module';
+import { GoLoaderModule } from '../go-loader/go-loader.module';
+import { GoButtonComponent } from './go-button.component';
 
 fdescribe('GoButtonComponent', () => {
   let component: GoButtonComponent;
@@ -227,14 +226,23 @@ fdescribe('GoButtonComponent', () => {
   });
 
   describe('toggleSplitButtonMenu', () => {
-    it('', () => {
+    it('toggles showSplitButtonMenu', () => {
+      expect(component.showSplitButtonMenu).toBe(false);
 
+      component.toggleSplitButtonMenu();
+
+      expect(component.showSplitButtonMenu).toBe(true);
     });
   });
 
   describe('splitButtonOptionSelected', () => {
-    it('', () => {
+    it('emits an event from splitButtonMenuEvent and sets splitButtonMenuEvent to false', () => {
+      component.showSplitButtonMenu = true;
+      component.splitButtonMenuEvent.subscribe((val: string) => expect(val).toBe('123'));
 
+      component.splitButtonOptionSelected('123');
+
+      expect(component.showSplitButtonMenu).toBe(false);
     });
   });
 

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
@@ -5,7 +5,7 @@ import { GoIconModule } from '../go-icon/go-icon.module';
 import { GoLoaderModule } from '../go-loader/go-loader.module';
 import { GoButtonComponent } from './go-button.component';
 
-fdescribe('GoButtonComponent', () => {
+describe('GoButtonComponent', () => {
   let component: GoButtonComponent;
   let fixture: ComponentFixture<GoButtonComponent>;
 
@@ -245,5 +245,4 @@ fdescribe('GoButtonComponent', () => {
       expect(component.showSplitButtonMenu).toBe(false);
     });
   });
-
 });

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
@@ -204,7 +204,7 @@ describe('GoButtonComponent', () => {
 
   describe('isSplitButton', () => {
     it('returns true if splitButtonOptions are present and buttonVariant is primary or secondary', () => {
-      component.splitButtonOptions = [{ value: '1', label: 'Option 1' }];
+      component.splitButtonOptions = [{ action: (): void => {}, label: 'Option 1' }];
       component.buttonVariant = 'secondary';
 
       expect(component.isSplitButton()).toBe(true);
@@ -236,12 +236,45 @@ describe('GoButtonComponent', () => {
   });
 
   describe('splitButtonOptionSelected', () => {
-    it('emits an event from splitButtonMenuEvent and sets splitButtonMenuEvent to false', () => {
+    it('calls the option\'s action and closes the menu', () => {
+      let testValue: string;
+      const testFunction: Function = function (): void {
+        testValue = 'Success!';
+      };
       component.showSplitButtonMenu = true;
-      component.splitButtonMenuEvent.subscribe((val: string) => expect(val).toBe('123'));
+      component.splitButtonOptions = [
+        { action: testFunction, label: 'Option 1' },
+      ];
 
-      component.splitButtonOptionSelected('123');
+      component.splitButtonOptionSelected(
+        component.splitButtonOptions[0].action
+      );
 
+      expect(testValue).toBe('Success!');
+      expect(component.showSplitButtonMenu).toBe(false);
+    });
+
+    it('successfully passes arguments to the option\'s action', () => {
+      let testValue: string;
+      const testFunction: Function = function (
+        arg1: string,
+        arg2: string
+      ): void {
+        testValue = arg1 + arg2;
+      };
+      component.showSplitButtonMenu = true;
+      component.splitButtonOptions = [
+        {
+          action: testFunction.bind(this, 'It is ', 'working!'),
+          label: 'Option 1',
+        },
+      ];
+
+      component.splitButtonOptionSelected(
+        component.splitButtonOptions[0].action
+      );
+
+      expect(testValue).toBe('It is working!');
       expect(component.showSplitButtonMenu).toBe(false);
     });
   });

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.spec.ts
@@ -6,7 +6,7 @@ import { GoLoaderModule } from '../go-loader/go-loader.module';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-describe('GoButtonComponent', () => {
+fdescribe('GoButtonComponent', () => {
   let component: GoButtonComponent;
   let fixture: ComponentFixture<GoButtonComponent>;
 
@@ -202,4 +202,40 @@ describe('GoButtonComponent', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('isSplitButton', () => {
+    it('returns true if splitButtonOptions are present and buttonVariant is primary or secondary', () => {
+      component.splitButtonOptions = [{ value: '1', label: 'Option 1' }];
+      component.buttonVariant = 'secondary';
+
+      expect(component.isSplitButton()).toBe(true);
+    });
+
+    it('returns false if splitButtonOptions are not present', () => {
+      component.splitButtonOptions = [];
+      component.buttonVariant = 'secondary';
+
+      expect(component.isSplitButton()).toBe(false);
+    });
+
+    it('returns false if buttonVariant is not primary or secondary', () => {
+      component.splitButtonOptions = [];
+      component.buttonVariant = 'tertiary';
+
+      expect(component.isSplitButton()).toBe(false);
+    });
+  });
+
+  describe('toggleSplitButtonMenu', () => {
+    it('', () => {
+
+    });
+  });
+
+  describe('splitButtonOptionSelected', () => {
+    it('', () => {
+
+    });
+  });
+
 });

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -16,6 +16,7 @@ import { fadeTemplateAnimation } from '../../animations/fade.animation';
 })
 export class GoButtonComponent implements OnChanges, OnInit {
   classObject: object = {};
+  dropdownClassObject: object = {};
   loaderClassObject: object = {};
   loaderType: 'light' | 'dark' = 'light';
 
@@ -54,6 +55,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
     };
 
     this.classObject['go-button--' + this.buttonVariant] = true;
+    this.dropdownClassObject['go-button--' + this.buttonVariant] = true;
   }
 
   private buttonLoader(): void {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -19,6 +19,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
   dropdownClassObject: object = {};
   loaderClassObject: object = {};
   loaderType: 'light' | 'dark' = 'light';
+  splitButtonIconModifier: 'light' | 'dark' = 'light';
 
   @Input() buttonDisabled: boolean;
   @Input() buttonIcon: string;
@@ -46,6 +47,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
 
   private setupButton(): void {
     this.buttonVariant = this.buttonVariant === 'positive' ? 'primary' : this.buttonVariant;
+    this.splitButtonIconModifier = this.buttonVariant === 'secondary' || this.buttonVariant === 'tertiary' ? 'dark' : 'light';
 
     this.classObject = {
       'go-button--dark': this.useDarkTheme,

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -29,7 +29,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
   @Input() buttonType: string = 'button';
   @Input() buttonVariant: string = 'primary';
   @Input() isProcessing: boolean = false;
-  @Input() splitButtonOptions: [] = [];
+  @Input() splitButtonOptions: string[] = [];
   @Input() useDarkTheme: boolean = false;
 
   @Output() handleClick: EventEmitter<boolean> = new EventEmitter<boolean>();

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -60,7 +60,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
   }
 
   isSplitButton(): boolean {
-    return this.splitButtonOptions.length && (this.buttonVariant === 'primary' || this.buttonVariant === 'secondary');
+    return this.splitButtonOptions.length > 0 && (this.buttonVariant === 'primary' || this.buttonVariant === 'secondary');
   }
 
   toggleSplitButtonMenu(): void {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -16,7 +16,7 @@ import { fadeTemplateAnimation } from '../../animations/fade.animation';
 })
 export class GoButtonComponent implements OnChanges, OnInit {
   classObject: object = {};
-  dropdownClassObject: object = {};
+  splitButtonClassObject: object = {};
   loaderClassObject: object = {};
   loaderType: 'light' | 'dark' = 'light';
   showSplitButtonMenu: boolean = false;
@@ -58,12 +58,11 @@ export class GoButtonComponent implements OnChanges, OnInit {
     this.classObject = {
       'go-button--dark': this.useDarkTheme,
       'go-button--loading': this.isProcessing,
-      // TODO: set this based on Input
       'go-button--split': this.splitButtonOptions.length
     };
 
     this.classObject['go-button--' + this.buttonVariant] = true;
-    this.dropdownClassObject['split-button--' + this.buttonVariant] = true;
+    this.splitButtonClassObject['split-button--' + this.buttonVariant] = true;
   }
 
   private buttonLoader(): void {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -49,6 +49,8 @@ export class GoButtonComponent implements OnChanges, OnInit {
     this.classObject = {
       'go-button--dark': this.useDarkTheme,
       'go-button--loading': this.isProcessing,
+      // TODO: set this based on Input
+      'go-button--split': true
     };
 
     this.classObject['go-button--' + this.buttonVariant] = true;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -19,6 +19,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
   dropdownClassObject: object = {};
   loaderClassObject: object = {};
   loaderType: 'light' | 'dark' = 'light';
+  showSplitButtonMenu: boolean = false;
   splitButtonIconModifier: 'light' | 'dark' = 'light';
 
   @Input() buttonDisabled: boolean;
@@ -44,6 +45,10 @@ export class GoButtonComponent implements OnChanges, OnInit {
   ngOnChanges(): void {
     this.setupButton();
     this.buttonLoader();
+  }
+
+  toggleSplitButtonMenu(): void {
+    this.showSplitButtonMenu = !this.showSplitButtonMenu;
   }
 
   private setupButton(): void {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -1,6 +1,8 @@
 import {
   Component,
+  ElementRef,
   EventEmitter,
+  HostListener,
   Input,
   OnChanges,
   OnInit,
@@ -31,6 +33,15 @@ export class GoButtonComponent implements OnChanges, OnInit {
   @Input() useDarkTheme: boolean = false;
 
   @Output() handleClick: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+  @HostListener('document:click', ['$event.target'])
+  onDocumentClick(target: HTMLElement): void {
+    this.closeSplitButtonMenuEvent(target);
+  }
+
+  constructor(
+    private elementRef: ElementRef,
+  ) { }
 
   clicked(): void {
     this.handleClick.emit(this.isProcessing);
@@ -84,5 +95,11 @@ export class GoButtonComponent implements OnChanges, OnInit {
 
   private isAlternativeLight(): boolean {
     return (this.buttonVariant === 'secondary' || this.buttonVariant === 'tertiary') && !this.useDarkTheme;
+  }
+
+  private closeSplitButtonMenuEvent(target: HTMLElement): void {
+    if (!this.elementRef.nativeElement.contains(target)) {
+      this.showSplitButtonMenu = false;
+    }
   }
 }

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -65,6 +65,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
 
   splitButtonOptionSelected(value: string): void {
     this.splitButtonMenuEvent.emit(value);
+    this.showSplitButtonMenu = false;
   }
 
   private setupButton(): void {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -59,6 +59,10 @@ export class GoButtonComponent implements OnChanges, OnInit {
     this.buttonLoader();
   }
 
+  isSplitButton(): boolean {
+    return this.splitButtonOptions.length && (this.buttonVariant === 'primary' || this.buttonVariant === 'secondary');
+  }
+
   toggleSplitButtonMenu(): void {
     this.showSplitButtonMenu = !this.showSplitButtonMenu;
   }
@@ -75,7 +79,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
     this.classObject = {
       'go-button--dark': this.useDarkTheme,
       'go-button--loading': this.isProcessing,
-      'go-button--split': this.splitButtonOptions.length
+      'go-button--split': this.isSplitButton()
     };
 
     this.classObject['go-button--' + this.buttonVariant] = true;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -29,10 +29,11 @@ export class GoButtonComponent implements OnChanges, OnInit {
   @Input() buttonType: string = 'button';
   @Input() buttonVariant: string = 'primary';
   @Input() isProcessing: boolean = false;
-  @Input() splitButtonOptions: string[] = [];
+  @Input() splitButtonOptions: {value: string, label: string}[] = [];
   @Input() useDarkTheme: boolean = false;
 
   @Output() handleClick: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() splitButtonMenuEvent: EventEmitter<string> = new EventEmitter<string>();
 
   @HostListener('document:click', ['$event.target'])
   onDocumentClick(target: HTMLElement): void {
@@ -60,6 +61,10 @@ export class GoButtonComponent implements OnChanges, OnInit {
 
   toggleSplitButtonMenu(): void {
     this.showSplitButtonMenu = !this.showSplitButtonMenu;
+  }
+
+  splitButtonOptionSelected(value: string): void {
+    this.splitButtonMenuEvent.emit(value);
   }
 
   private setupButton(): void {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -9,6 +9,7 @@ import {
   Output,
 } from '@angular/core';
 import { fadeTemplateAnimation } from '../../animations/fade.animation';
+import { SplitButtonOption } from './go-split-button-option.model';
 
 @Component({
   animations: [fadeTemplateAnimation],
@@ -29,11 +30,10 @@ export class GoButtonComponent implements OnChanges, OnInit {
   @Input() buttonType: string = 'button';
   @Input() buttonVariant: string = 'primary';
   @Input() isProcessing: boolean = false;
-  @Input() splitButtonOptions: { value: string, label: string }[] = [];
+  @Input() splitButtonOptions: SplitButtonOption[] = [];
   @Input() useDarkTheme: boolean = false;
 
   @Output() handleClick: EventEmitter<boolean> = new EventEmitter<boolean>();
-  @Output() splitButtonMenuEvent: EventEmitter<string> = new EventEmitter<string>();
 
   @HostListener('document:click', ['$event.target'])
   onDocumentClick(target: HTMLElement): void {
@@ -67,8 +67,8 @@ export class GoButtonComponent implements OnChanges, OnInit {
     this.showSplitButtonMenu = !this.showSplitButtonMenu;
   }
 
-  splitButtonOptionSelected(value: string): void {
-    this.splitButtonMenuEvent.emit(value);
+  splitButtonOptionSelected(action: SplitButtonOption['action']): void {
+    action.apply(this, arguments);
     this.showSplitButtonMenu = false;
   }
 

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -29,7 +29,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
   @Input() buttonType: string = 'button';
   @Input() buttonVariant: string = 'primary';
   @Input() isProcessing: boolean = false;
-  @Input() splitButtonOptions: {value: string, label: string}[] = [];
+  @Input() splitButtonOptions: { value: string, label: string }[] = [];
   @Input() useDarkTheme: boolean = false;
 
   @Output() handleClick: EventEmitter<boolean> = new EventEmitter<boolean>();

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -55,7 +55,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
     };
 
     this.classObject['go-button--' + this.buttonVariant] = true;
-    this.dropdownClassObject['go-button--' + this.buttonVariant] = true;
+    this.dropdownClassObject['dropdown__button--' + this.buttonVariant] = true;
   }
 
   private buttonLoader(): void {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -26,6 +26,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
   @Input() buttonType: string = 'button';
   @Input() buttonVariant: string = 'primary';
   @Input() isProcessing: boolean = false;
+  @Input() splitButtonOptions: [] = [];
   @Input() useDarkTheme: boolean = false;
 
   @Output() handleClick: EventEmitter<boolean> = new EventEmitter<boolean>();
@@ -53,7 +54,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
       'go-button--dark': this.useDarkTheme,
       'go-button--loading': this.isProcessing,
       // TODO: set this based on Input
-      'go-button--split': true
+      'go-button--split': this.splitButtonOptions.length
     };
 
     this.classObject['go-button--' + this.buttonVariant] = true;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.ts
@@ -58,7 +58,7 @@ export class GoButtonComponent implements OnChanges, OnInit {
     };
 
     this.classObject['go-button--' + this.buttonVariant] = true;
-    this.dropdownClassObject['dropdown__button--' + this.buttonVariant] = true;
+    this.dropdownClassObject['split-button--' + this.buttonVariant] = true;
   }
 
   private buttonLoader(): void {

--- a/projects/go-lib/src/lib/components/go-button/go-split-button-option.model.ts
+++ b/projects/go-lib/src/lib/components/go-button/go-split-button-option.model.ts
@@ -1,0 +1,4 @@
+export interface SplitButtonOption {
+  label: string;
+  action: Function;
+}

--- a/projects/go-lib/src/public_api.ts
+++ b/projects/go-lib/src/public_api.ts
@@ -19,6 +19,7 @@ export * from './lib/components/go-badge/go-badge.component';
 export * from './lib/components/go-badge/go-badge.module';
 
 // Button
+export * from './lib/components/go-button/go-split-button-option.model';
 export * from './lib/components/go-button/go-button.component';
 export * from './lib/components/go-button/go-button.module';
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
@@ -44,7 +44,7 @@
           <div class="go-column go-column--100">
             <h4 class="go-heading-4">buttonIcon</h4>
             <p class="go-body-copy">
-              Add an icon to the left of the text in the button. See the 
+              Add an icon to the left of the text in the button. See the
               <a class="go-link" href="https://material.io/tools/icons/">Material Design System Icons</a>
               page for available icons.
             </p>
@@ -63,7 +63,7 @@
           <div class="go-column go-column--100">
             <h4 class="go-heading-4">handleClick</h4>
             <p class="go-body-copy">
-              This event fires when the button is clicked. Use this event 
+              This event fires when the button is clicked. Use this event
               to handle the click event.
             </p>
           </div>
@@ -138,16 +138,16 @@
       <code [highlight]="primaryExample"></code>
       <div class="go-container">
         <div class="go-column go-column--25">
-          <go-button (handleClick)="testClick()">Primary</go-button>
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()">Primary</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
         </div>
       </div>
     </ng-container>
@@ -166,16 +166,16 @@
       <code [highlight]="secondaryExample"></code>
       <div class="go-container">
         <div class="go-column go-column--25">
-          <go-button buttonVariant="secondary" (handleClick)="testClick()">Secondary</go-button>
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()">Secondary</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button buttonVariant="secondary" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
         </div>
       </div>
     </ng-container>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
@@ -480,31 +480,82 @@
       <p class="go-body-copy">
         Lorem ipsum.
       </p>
-      <code [highlight]="splitExample"></code>
+      <h4 class="go-heading-4">example.ts</h4>
+      <code [highlight]="splitExampleTS"></code>
+      <h4 class="go-heading-4">example.html</h4>
+      <code [highlight]="splitExampleHTML"></code>
       <div class="go-container">
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()">Primary</go-button>
+          <go-button
+            (handleClick)="testClick()"
+            [splitButtonOptions]="splitButtonOptions"
+            (splitButtonMenuEvent)="testSplitButtonClick($event)">
+            Primary
+          </go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
+          <go-button
+            (handleClick)="testClick()"
+            [splitButtonOptions]="splitButtonOptions"
+            (splitButtonMenuEvent)="testSplitButtonClick($event)"
+            buttonDisabled="true">
+            Disabled
+          </go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
+          <go-button
+            (handleClick)="testClick()"
+            [splitButtonOptions]="splitButtonOptions"
+            (splitButtonMenuEvent)="testSplitButtonClick($event)"
+            buttonIcon="work">
+            With Icon
+          </go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
+          <go-button
+            (handleClick)="testClick()"
+            [splitButtonOptions]="splitButtonOptions"
+            (splitButtonMenuEvent)="testSplitButtonClick($event)"
+            buttonIcon="work">
+          </go-button> Icon Only
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()">Secondary</go-button>
+          <go-button
+            (handleClick)="testClick()"
+            [splitButtonOptions]="splitButtonOptions"
+            (splitButtonMenuEvent)="testSplitButtonClick($event)"
+            buttonVariant="secondary">
+            Secondary
+          </go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
+          <go-button
+            (handleClick)="testClick()"
+            [splitButtonOptions]="splitButtonOptions"
+            (splitButtonMenuEvent)="testSplitButtonClick($event)"
+            buttonVariant="secondary"
+            buttonDisabled="true">
+            Disabled
+          </go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
+          <go-button
+            (handleClick)="testClick()"
+            [splitButtonOptions]="splitButtonOptions"
+            (splitButtonMenuEvent)="testSplitButtonClick($event)"
+            buttonVariant="secondary"
+            buttonIcon="work">
+            With Icon
+          </go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
+          <go-button
+            (handleClick)="testClick()"
+            [splitButtonOptions]="splitButtonOptions"
+            (splitButtonMenuEvent)="testSplitButtonClick($event)"
+            buttonVariant="secondary"
+            buttonIcon="work">
+          </go-button> Icon Only
         </div>
       </div>
     </ng-container>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
@@ -478,8 +478,18 @@
     </ng-container>
     <ng-container go-card-content>
       <p class="go-body-copy">
-        Lorem ipsum.
+        The <code class="code-block--inline">splitButtonOptions</code> input allows
+        you to turn the <code class="code-block--inline">go-button</code> into a split-button.
+        The options should consist of an array of objects each with a
+        <code class="code-block--inline">label</code> and a
+        <code class="code-block--inline">value</code> property. The
+        <code class="code-block--inline">label</code> will determine the text displayed
+        for that option in the split-button's dropdown menu. Clicking an option will emit
+        an event with the option’s <code class="code-block--inline">value</code>.
       </p>
+      <caption>
+        NOTE: Currently, only the Primary and Secondary button types support split-button functionality.
+      </caption>
       <h4 class="go-heading-4">example.ts</h4>
       <code [highlight]="splitExampleTS"></code>
       <h4 class="go-heading-4">example.html</h4>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
@@ -61,20 +61,6 @@
           </div>
 
           <div class="go-column go-column--100">
-            <h4 class="go-heading-4">handleClick</h4>
-            <p class="go-body-copy">
-              This event fires when the button is clicked. Use this event
-              to handle the click event.
-            </p>
-          </div>
-
-        </div>
-      </div>
-
-      <div class="go-column go-column--50 go-column--no-padding">
-        <div class="go-container">
-
-          <div class="go-column go-column--100">
             <h4 class="go-heading-4">buttonVariant</h4>
             <p class="go-body-copy">
               The <code class="code-block--inline">buttonVariant</code>
@@ -91,6 +77,12 @@
             </ol>
           </div>
 
+        </div>
+      </div>
+
+      <div class="go-column go-column--50 go-column--no-padding">
+        <div class="go-container">
+
           <div class="go-column go-column--100">
             <h4 class="go-heading-4">isProcessing</h4>
             <p class="go-body-copy">
@@ -102,12 +94,29 @@
           </div>
 
           <div class="go-column go-column--100">
+            <h4 class="go-heading-4">splitButtonOptions</h4>
+            <p class="go-body-copy">
+              Turns the button into a split-button, where the left side
+              functions as a normal button and right side opens a dropdown
+              menu with options for alternative actions.
+            </p>
+          </div>
+
+          <div class="go-column go-column--100">
             <h4 class="go-heading-4">useDarkTheme</h4>
             <p class="go-body-copy">
               Applies a dark theme to the button component.
               The dark button styles can be applied by setting the
               <code class="code-block--inline">useDarkTheme</code>
               binding to <code class="code-block--inline">true</code>.
+            </p>
+          </div>
+
+          <div class="go-column go-column--100">
+            <h4 class="go-heading-4">handleClick</h4>
+            <p class="go-body-copy">
+              This event fires when the button is clicked. Use this event
+              to handle the click event.
             </p>
           </div>
 
@@ -471,10 +480,10 @@
     </ng-container>
   </go-card>
 
-  <go-card class="go-column go-column--100" id="primary-buttons">
+  <go-card class="go-column go-column--100" id="split-buttons">
     <ng-container go-card-header>
       <h2 class="go-heading-2 go-heading--no-wrap">Split Buttons</h2>
-      <go-copy cardId="primary-buttons" goCopyCardLink></go-copy>
+      <go-copy cardId="split-buttons" goCopyCardLink></go-copy>
     </ng-container>
     <ng-container go-card-content>
       <p class="go-body-copy">
@@ -485,7 +494,8 @@
         <code class="code-block--inline">value</code> property. The
         <code class="code-block--inline">label</code> will determine the text displayed
         for that option in the split-button's dropdown menu. Clicking an option will emit
-        an event with the option’s <code class="code-block--inline">value</code>.
+        an event with the option’s <code class="code-block--inline">value</code> from
+        <code class="code-block--inline">splitButtonMenuEvent</code>.
       </p>
       <caption>
         NOTE: Currently, only the Primary and Secondary button types support split-button functionality.

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
@@ -487,29 +487,44 @@
     </ng-container>
     <ng-container go-card-content>
       <p class="go-body-copy">
-        The <code class="code-block--inline">splitButtonOptions</code> input allows
-        you to turn the <code class="code-block--inline">go-button</code> into a split-button.
-        The options should consist of an array of objects each with a
-        <code class="code-block--inline">label</code> and a
-        <code class="code-block--inline">value</code> property. The
-        <code class="code-block--inline">label</code> will determine the text displayed
-        for that option in the split-button's dropdown menu. Clicking an option will emit
-        an event with the option’s <code class="code-block--inline">value</code> from
-        <code class="code-block--inline">splitButtonMenuEvent</code>.
+        The <code class="code-block--inline">@Input() splitButtonOptions: SplitButtonOption[]</code>
+        input allows you to turn the button into a split-button.
       </p>
-      <caption>
-        NOTE: Currently, only the Primary and Secondary button types support split-button functionality.
-      </caption>
+
+      <p class="go-body-copy">
+        The interface for the options looks like this:
+      </p>
+      <code [highlight]="splitButtonOptionInterface"></code>
+
+      <p class="go-body-copy">
+        The <code class="code-block--inline">label</code> of an option will determine the
+        text displayed for that option in the split-button's dropdown menu.
+      </p>
+
+      <p class="go-body-copy">
+        The <code class="code-block--inline">action</code> of an option is the function
+        that will be called when the action is clicked.
+        In order for the function to be able to reference properties on the component
+        class on which it is defined and to be able to receive arguments, you must bind
+        <code class="code-block--inline">this</code> to the context of the function (see below).
+      </p>
+
       <h4 class="go-heading-4">example.ts</h4>
       <code [highlight]="splitExampleTS"></code>
+
       <h4 class="go-heading-4">example.html</h4>
       <code [highlight]="splitExampleHTML"></code>
+
+      <caption>
+        <strong>NOTE:</strong> Currently, only the Primary and Secondary button types
+        support split-button functionality.
+      </caption>
+
       <div class="go-container">
         <div class="go-column go-column--25">
           <go-button
             (handleClick)="testClick()"
-            [splitButtonOptions]="splitButtonOptions"
-            (splitButtonMenuEvent)="testSplitButtonClick($event)">
+            [splitButtonOptions]="splitButtonOptions">
             Primary
           </go-button>
         </div>
@@ -517,7 +532,6 @@
           <go-button
             (handleClick)="testClick()"
             [splitButtonOptions]="splitButtonOptions"
-            (splitButtonMenuEvent)="testSplitButtonClick($event)"
             buttonDisabled="true">
             Disabled
           </go-button>
@@ -526,7 +540,6 @@
           <go-button
             (handleClick)="testClick()"
             [splitButtonOptions]="splitButtonOptions"
-            (splitButtonMenuEvent)="testSplitButtonClick($event)"
             buttonIcon="work">
             With Icon
           </go-button>
@@ -535,7 +548,6 @@
           <go-button
             (handleClick)="testClick()"
             [splitButtonOptions]="splitButtonOptions"
-            (splitButtonMenuEvent)="testSplitButtonClick($event)"
             buttonIcon="work">
           </go-button> Icon Only
         </div>
@@ -543,7 +555,6 @@
           <go-button
             (handleClick)="testClick()"
             [splitButtonOptions]="splitButtonOptions"
-            (splitButtonMenuEvent)="testSplitButtonClick($event)"
             buttonVariant="secondary">
             Secondary
           </go-button>
@@ -552,7 +563,6 @@
           <go-button
             (handleClick)="testClick()"
             [splitButtonOptions]="splitButtonOptions"
-            (splitButtonMenuEvent)="testSplitButtonClick($event)"
             buttonVariant="secondary"
             buttonDisabled="true">
             Disabled
@@ -562,7 +572,6 @@
           <go-button
             (handleClick)="testClick()"
             [splitButtonOptions]="splitButtonOptions"
-            (splitButtonMenuEvent)="testSplitButtonClick($event)"
             buttonVariant="secondary"
             buttonIcon="work">
             With Icon
@@ -572,7 +581,6 @@
           <go-button
             (handleClick)="testClick()"
             [splitButtonOptions]="splitButtonOptions"
-            (splitButtonMenuEvent)="testSplitButtonClick($event)"
             buttonVariant="secondary"
             buttonIcon="work">
           </go-button> Icon Only

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.html
@@ -138,16 +138,16 @@
       <code [highlight]="primaryExample"></code>
       <div class="go-container">
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()">Primary</go-button>
+          <go-button (handleClick)="testClick()">Primary</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
+          <go-button (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
+          <go-button (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
+          <go-button (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
         </div>
       </div>
     </ng-container>
@@ -166,16 +166,16 @@
       <code [highlight]="secondaryExample"></code>
       <div class="go-container">
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()">Secondary</go-button>
+          <go-button buttonVariant="secondary" (handleClick)="testClick()">Secondary</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
+          <go-button buttonVariant="secondary" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
+          <go-button buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
         </div>
         <div class="go-column go-column--25">
-          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
+          <go-button buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
         </div>
       </div>
     </ng-container>
@@ -443,7 +443,7 @@
     </ng-container>
   </go-card>
 
-  <go-card class="go-column go-column--100 go-column--no-padding" id="button-group">
+  <go-card class="go-column go-column--100" id="button-group">
     <ng-container go-card-header>
       <h2 class="go-heading-2 go-heading--no-wrap">Button Groups</h2>
       <go-copy cardId="button-group" goCopyCardLink></go-copy>
@@ -466,6 +466,45 @@
               <go-button>Button 2</go-button>
             </li>
           </ul>
+        </div>
+      </div>
+    </ng-container>
+  </go-card>
+
+  <go-card class="go-column go-column--100" id="primary-buttons">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Split Buttons</h2>
+      <go-copy cardId="primary-buttons" goCopyCardLink></go-copy>
+    </ng-container>
+    <ng-container go-card-content>
+      <p class="go-body-copy">
+        Lorem ipsum.
+      </p>
+      <code [highlight]="splitExample"></code>
+      <div class="go-container">
+        <div class="go-column go-column--25">
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()">Primary</go-button>
+        </div>
+        <div class="go-column go-column--25">
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
+        </div>
+        <div class="go-column go-column--25">
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
+        </div>
+        <div class="go-column go-column--25">
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
+        </div>
+        <div class="go-column go-column--25">
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()">Secondary</go-button>
+        </div>
+        <div class="go-column go-column--25">
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonDisabled="true">Disabled</go-button>
+        </div>
+        <div class="go-column go-column--25">
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work">With Icon</go-button>
+        </div>
+        <div class="go-column go-column--25">
+          <go-button [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]" buttonVariant="secondary" (handleClick)="testClick()" buttonIcon="work"></go-button> Icon Only
         </div>
       </div>
     </ng-container>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
@@ -90,6 +90,43 @@ export class ButtonDocsComponent {
   </ul>
   `;
 
+  splitExample: string = `
+  <div class="go-column go-column--25">
+    <go-button
+      [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]"
+      buttonVariant="secondary"
+      (handleClick)="testClick()">
+      Secondary
+    </go-button>
+  </div>
+  <div class="go-column go-column--25">
+    <go-button
+      [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]"
+      buttonVariant="secondary"
+      (handleClick)="testClick()"
+      buttonDisabled="true">
+      Disabled
+    </go-button>
+  </div>
+  <div class="go-column go-column--25">
+    <go-button
+      [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]"
+      buttonVariant="secondary"
+      (handleClick)="testClick()"
+      buttonIcon="work">
+      With Icon
+    </go-button>
+  </div>
+  <div class="go-column go-column--25">
+    <go-button
+      [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]"
+      buttonVariant="secondary"
+      (handleClick)="testClick()"
+      buttonIcon="work">
+    </go-button> Icon Only
+  </div>
+  `;
+
   linkToSource: string = 'https://github.com/mobi/goponents/tree/dev/projects/go-lib/src/lib/components/go-button';
 
   constructor(private titleCasePipe: TitleCasePipe) { }

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
@@ -29,11 +29,13 @@ export class ButtonDocsComponent {
   negativeDarkButtonLoading: boolean = false;
 
   pageTitle: string = 'Button';
+
   splitButtonOptions: { value: string; label: string }[] = [
     { value: '1', label: 'Option 1' },
     { value: '2', label: 'Option 2' },
     { value: '3', label: 'Option 3' },
   ];
+
   componentBindings: string = `
   @Input() buttonDisabled: boolean;
   @Input() buttonIcon: string;

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 
 import { GoButtonComponent } from '../../../../../../../go-lib/src/public_api';
 import { TitleCasePipe } from '@angular/common';
+import { SplitButtonOption } from 'projects/go-lib/src/lib/components/go-button/go-split-button-option.model';
 
 @Component({
   selector: 'app-button-docs',
@@ -30,11 +31,25 @@ export class ButtonDocsComponent {
 
   pageTitle: string = 'Button';
 
-  splitButtonOptions: { value: string; label: string }[] = [
-    { value: '1', label: 'Option 1' },
-    { value: '2', label: 'Option 2' },
-    { value: '3', label: 'Option 3' },
+  splitButtonOptions: SplitButtonOption[] = [
+    {
+      action: this.testSplitButtonOption.bind(this),
+      label: 'Option 1'
+    },
+    {
+      action: this.testSplitButtonOptionWithArgs.bind(this, '2'),
+      label: 'Option 2'
+    },
+    {
+      action: this.testSplitButtonOptionWithArgs.bind(this, '3'),
+      label: 'Option 3'
+    },
+    {
+      action: this.testSplitButtonOptionWithComponentProp.bind(this),
+      label: 'Option 4'
+    },
   ];
+  testMessage: string = 'This message is from a component property';
 
   componentBindings: string = `
   @Input() buttonDisabled: boolean;
@@ -42,7 +57,7 @@ export class ButtonDocsComponent {
   @Input() buttonType: string = 'button';
   @Input() buttonVariant: string = 'primary';
   @Input() isProcessing: boolean = false;
-  @Input() splitButtonOptions: { value: string, label: string }[] = [];
+  @Input() splitButtonOptions: SplitButtonOption[] = [];
   @Input() useDarkTheme: boolean = false;
 
   @Output() handleClick = new EventEmitter<boolean>();
@@ -96,23 +111,53 @@ export class ButtonDocsComponent {
   </ul>
   `;
 
+  splitButtonOptionInterface: string = `
+  export interface SplitButtonOption {
+    label: string;
+    action: Function;
+  }
+  `;
+
   splitExampleTS: string = `
-  splitButtonOptions: { value: string; label: string }[] = [
-    { value: '1', label: 'Option 1' },
-    { value: '2', label: 'Option 2' },
-    { value: '3', label: 'Option 3' },
+  splitButtonOptions: SplitButtonOption[] = [
+    // Basic function
+    {
+      action: this.testSplitButtonOption,
+      label: 'Option 1'
+    },
+    // Function with arguments
+    {
+      action: this.testSplitButtonOptionWithArgs.bind(this, '2'),
+      label: 'Option 2'
+    },
+    {
+      action: this.testSplitButtonOptionWithArgs.bind(this, '3'),
+      label: 'Option 3'
+    },
+    // Function that references a component property
+    {
+      action: this.testSplitButtonOptionWithComponentProp.bind(this),
+      label: 'Option 4'
+    },
   ];
 
-  testSplitButtonClick(value: string): void {
-    alert(\`Split Button option \${value}\ clicked!\`);
+  testSplitButtonOption(): void {
+    alert('Split button Option 1 clicked!');
+  }
+
+  testSplitButtonOptionWithArgs(arg: string): void {
+    alert(\`Split button Option \${arg} clicked!\`);
+  }
+
+  testSplitButtonOptionWithComponentProp(): void {
+    alert(this.testClick);
   }
   `;
 
   splitExampleHTML: string = `
   <go-button
     (handleClick)="testClick()"
-    [splitButtonOptions]="splitButtonOptions"
-    (splitButtonMenuEvent)="testSplitClick($event)">
+    [splitButtonOptions]="splitButtonOptions">
     Primary
   </go-button>
   `;
@@ -132,8 +177,16 @@ export class ButtonDocsComponent {
     }, 3800);
   }
 
-  testSplitButtonClick(value: string): void {
-    alert(`Split Button option ${value} clicked!`);
+  testSplitButtonOption(): void {
+    alert('Split button Option 1 clicked!');
+  }
+
+  testSplitButtonOptionWithArgs(arg: string): void {
+    alert(`Split button Option ${arg} clicked!`);
+  }
+
+  testSplitButtonOptionWithComponentProp(): void {
+    alert(this.testMessage);
   }
 
   private buttonTemplate(variant: string, icon: string): string {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
@@ -150,7 +150,7 @@ export class ButtonDocsComponent {
   }
 
   testSplitButtonOptionWithComponentProp(): void {
-    alert(this.testClick);
+    alert(this.testMessage);
   }
   `;
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
@@ -38,9 +38,10 @@ export class ButtonDocsComponent {
   @Input() buttonDisabled: boolean;
   @Input() buttonIcon: string;
   @Input() buttonType: string = 'button';
-  @Input() buttonVariant: string;
-  @Input() isProcessing: boolean;
-  @Input() useDarkTheme: boolean;
+  @Input() buttonVariant: string = 'primary';
+  @Input() isProcessing: boolean = false;
+  @Input() splitButtonOptions: { value: string, label: string }[] = [];
+  @Input() useDarkTheme: boolean = false;
 
   @Output() handleClick = new EventEmitter<boolean>();
   `;

--- a/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/button-docs/button-docs.component.ts
@@ -29,8 +29,11 @@ export class ButtonDocsComponent {
   negativeDarkButtonLoading: boolean = false;
 
   pageTitle: string = 'Button';
-
-
+  splitButtonOptions: { value: string; label: string }[] = [
+    { value: '1', label: 'Option 1' },
+    { value: '2', label: 'Option 2' },
+    { value: '3', label: 'Option 3' },
+  ];
   componentBindings: string = `
   @Input() buttonDisabled: boolean;
   @Input() buttonIcon: string;
@@ -90,41 +93,25 @@ export class ButtonDocsComponent {
   </ul>
   `;
 
-  splitExample: string = `
-  <div class="go-column go-column--25">
-    <go-button
-      [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]"
-      buttonVariant="secondary"
-      (handleClick)="testClick()">
-      Secondary
-    </go-button>
-  </div>
-  <div class="go-column go-column--25">
-    <go-button
-      [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]"
-      buttonVariant="secondary"
-      (handleClick)="testClick()"
-      buttonDisabled="true">
-      Disabled
-    </go-button>
-  </div>
-  <div class="go-column go-column--25">
-    <go-button
-      [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]"
-      buttonVariant="secondary"
-      (handleClick)="testClick()"
-      buttonIcon="work">
-      With Icon
-    </go-button>
-  </div>
-  <div class="go-column go-column--25">
-    <go-button
-      [splitButtonOptions]="[{action: '', label: 'Option 1'},{action: '', label: 'Option 2'}]"
-      buttonVariant="secondary"
-      (handleClick)="testClick()"
-      buttonIcon="work">
-    </go-button> Icon Only
-  </div>
+  splitExampleTS: string = `
+  splitButtonOptions: { value: string; label: string }[] = [
+    { value: '1', label: 'Option 1' },
+    { value: '2', label: 'Option 2' },
+    { value: '3', label: 'Option 3' },
+  ];
+
+  testSplitButtonClick(value: string): void {
+    alert(\`Split Button option \${value}\ clicked!\`);
+  }
+  `;
+
+  splitExampleHTML: string = `
+  <go-button
+    (handleClick)="testClick()"
+    [splitButtonOptions]="splitButtonOptions"
+    (splitButtonMenuEvent)="testSplitClick($event)">
+    Primary
+  </go-button>
   `;
 
   linkToSource: string = 'https://github.com/mobi/goponents/tree/dev/projects/go-lib/src/lib/components/go-button';
@@ -140,6 +127,10 @@ export class ButtonDocsComponent {
     setTimeout(() => {
       this[button + 'Loading'] = false;
     }, 3800);
+  }
+
+  testSplitButtonClick(value: string): void {
+    alert(`Split Button option ${value} clicked!`);
   }
 
   private buttonTemplate(variant: string, icon: string): string {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #602

## What is the new behavior?
Adds ability to turn a `go-button` into a split-button (only for primary and secondary button variants).

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
