### PR TITLE
Emit rowSelectionEvent when selecting or deselecting all table rows

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table-selection.model.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table-selection.model.ts
@@ -2,7 +2,7 @@ export interface RowSelectionEvent extends SelectionState {
   /**
    * The current row that was targeted for selection
    */
-  currentRow?: {
+  currentRow: {
     /**
      * The entire data in the row
      */

--- a/projects/go-lib/src/lib/components/go-table/go-table-selection.model.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table-selection.model.ts
@@ -2,7 +2,7 @@ export interface RowSelectionEvent extends SelectionState {
   /**
    * The current row that was targeted for selection
    */
-  currentRow: {
+  currentRow?: {
     /**
      * The entire data in the row
      */

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -420,6 +420,19 @@ describe('GoTableComponent', () => {
 
       expect(component.targetedRows).toEqual([]);
     });
+
+    it('should emit a rowSelectionEvent when selectAll is toggled', () => {
+      const selectionEventData: RowSelectionEvent = {
+        deselectedRows: [],
+        selectionMode: SelectionMode.selection,
+        selectedRows: []
+      };
+      spyOn(component.rowSelectionEvent, 'emit');
+
+      component.selectAllControl.setValue(false);
+
+      expect(component.rowSelectionEvent.emit).toHaveBeenCalledWith(selectionEventData);
+    });
   });
 
   describe('getSelectionCount', () => {

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -421,17 +421,17 @@ describe('GoTableComponent', () => {
       expect(component.targetedRows).toEqual([]);
     });
 
-    it('should emit a rowSelectionEvent when selectAll is toggled', () => {
-      const selectionEventData: RowSelectionEvent = {
+    it('should emit a SelectionState event when selectAll is toggled', () => {
+      const selectionEventData: SelectionState = {
         deselectedRows: [],
         selectionMode: SelectionMode.selection,
         selectedRows: []
       };
-      spyOn(component.rowSelectionEvent, 'emit');
+      spyOn(component.selectAllEvent, 'emit');
 
       component.selectAllControl.setValue(false);
 
-      expect(component.rowSelectionEvent.emit).toHaveBeenCalledWith(selectionEventData);
+      expect(component.selectAllEvent.emit).toHaveBeenCalledWith(selectionEventData);
     });
   });
 

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -520,6 +520,12 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit, OnDes
         if (!this.selectAllControl.value) {
           this.selectAllIndeterminate = false;
         }
+
+        this.rowSelectionEvent.emit({
+          deselectedRows: this.selectAllControl.value ? this.targetedRows : [],
+          selectionMode: this.determineSelectionMode(),
+          selectedRows: !this.selectAllControl.value ? this.targetedRows : []
+        });
       }
     );
     this.subsCollection.add(selectAllSub);

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -54,13 +54,21 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit, OnDes
 
   /**
    * This event is emitted when a row's selection changes
-   * @returns a `GoTableRowSelectionEvent` object.
+   * @returns a `RowSelectionEvent` object.
    * - `currentRow` is the targeted row
    * - `selectedRows` are the currently selected rows if the `selectionMode` is `selection`
    * - `selectionMode` is a `GoTableSelectionMode` enum of either `selection` or `deselection`
    * - `deselectedRows` are the currently deselected rows if the `selectionMode` is `deselection`
    */
   @Output() rowSelectionEvent: EventEmitter<RowSelectionEvent> = new EventEmitter<RowSelectionEvent>();
+  /**
+   * This event is emitted when the value of the selectAllControl changes
+   * @returns a `SelectionState` object.
+   * - `selectedRows` are the currently selected rows if the `selectionMode` is `selection`
+   * - `selectionMode` is a `GoTableSelectionMode` enum of either `selection` or `deselection`
+   * - `deselectedRows` are the currently deselected rows if the `selectionMode` is `deselection`
+   */
+  @Output() selectAllEvent: EventEmitter<SelectionState> = new EventEmitter<SelectionState>();
   @Output() tableChange: EventEmitter<GoTableConfig> = new EventEmitter<GoTableConfig>();
 
   @ContentChildren(GoTableColumnComponent) columns: QueryList<GoTableColumnComponent>;
@@ -521,7 +529,7 @@ export class GoTableComponent implements OnInit, OnChanges, AfterViewInit, OnDes
           this.selectAllIndeterminate = false;
         }
 
-        this.rowSelectionEvent.emit({
+        this.selectAllEvent.emit({
           deselectedRows: this.selectAllControl.value ? this.targetedRows : [],
           selectionMode: this.determineSelectionMode(),
           selectedRows: !this.selectAllControl.value ? this.targetedRows : []

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-selection/table-selection.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-selection/table-selection.component.html
@@ -54,18 +54,38 @@
     </ng-container>
     <ng-container go-card-content>
       <p class="go-body-copy">
-        There are two ways to interact with the selected items of the table.
-        By using an element reference on the table and/or using the <code class="code-block--inline">(rowSelectionEvent)</code> event.
+        There are two ways to interact with the selected items of the table:
       </p>
+      <ol class="go-ordered-list">
+        <li class="go-ordered-list__item">
+          By binding to the table's selection event outputs (the subject of this card).
+        </li>
+        <li class="go-ordered-list__item">
+          By using an element reference to the table (see the "Element Reference Interection" card below).
+        </li>
+      </ol>
+      <h4 class="go-heading-4">Binding to the table's selection events</h4>
+
+      <p class="go-body-copy">There are two outputs that emit selection events from the table</p>
+      <code [highlight]="tableSelectionEventOutputs"></code>
+
       <p class="go-body-copy">
-        First, you must understand how the table handles selection. See the <code class="code-block--inline">SelectionState</code> interface for an explanation:
+        The interfaces for the <code class="code-block--inline">RowSelectionEvent</code> and the
+        <code class="code-block--inline">SelectionState</code> provide more information about the
+        structure of these events:
       </p>
-      <code [highlight]="tableSelectModels"></code>
+      <code [highlight]="tableSelectionModels"></code>
       <p class="go-body-copy">
-        In selection mode, the user is selecting individual rows. This means that these selected rows are being added to the selectedRows array.
+        To summarize: in selection mode, the user is selecting individual rows. This means that these selected rows are being added to the selectedRows array.
         In deselection mode, the user has checked the 'check all' check box and is now removing items from the selection; we call this deselection.
         In this case, items are added to the deselectedRows array as the user unchecks them.
       </p>
+
+      <h4 class="go-heading-4">example.html</h4>
+      <code [highlight]="tableSelectionExample_html"></code>
+      <h4 class="go-heading-4">example.ts</h4>
+      <code [highlight]="tableSelectionExample_ts"></code>
+
       <p class="go-body-copy">
         Interact with the table below to see how the selection works.
       </p>
@@ -78,6 +98,7 @@
     tableTitle="Interactive Example of Selection States"
     [showTableActions]="true"
     (rowSelectionEvent)="tableRowEvent($event)"
+    (selectAllEvent)="selectAllEvent($event)"
     #interactiveTable>
     <ng-container go-table-actions>
       <go-button (handleClick)="interactiveTableState()">State</go-button>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-selection/table-selection.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-selection/table-selection.component.ts
@@ -188,14 +188,17 @@ export class TableSelectionComponent {
 
   tableRowEvent(rowEvent: RowSelectionEvent): void {
     this.toasterService.toastInfo({ header: 'Row Event', message: 'Selection Mode: ' + rowEvent.selectionMode + '. ' }, 6000);
-    this.toasterService.toastInfo(
-      {
-        header: 'Row Event',
-        // tslint:disable-next-line: max-line-length
-        message: 'Current Row Id: ' + rowEvent.currentRow.data['id'] + ', ' + (rowEvent.currentRow.selected ? 'selected' : 'deselected') + '. '
-      }, 6000);
     this.toasterService.toastInfo({ header: 'Row Event', message: 'Selected Row Count: ' + rowEvent.selectedRows.length + '. ' }, 6000);
     this.toasterService.toastInfo({ header: 'Row Event', message: 'Deselected Row Count: ' + rowEvent.deselectedRows.length + '. ' }, 6000);
+    if (rowEvent.currentRow) {
+      this.toasterService.toastInfo(
+        {
+          header: 'Row Event',
+          message: `Current Row Id: ${rowEvent.currentRow.data['id']}, ${rowEvent.currentRow.selected ? 'selected' : 'deselected'}.`
+        },
+        6000
+      );
+    }
   }
 
   interactiveTableState(): void {

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-selection/table-selection.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-selection/table-selection.component.ts
@@ -25,31 +25,68 @@ export class TableSelectionComponent {
   }
   `;
 
-  tableSelectModels: string = `
+  tableSelectionEventOutputs: string = `
+  // Emits a \`RowSelectionEvent\` event when an individual row is selected or deselected.
+  @Output() rowSelectionEvent: EventEmitter<RowSelectionEvent> = new EventEmitter<RowSelectionEvent>();
+  // Emits a \`SelectionState\` event when all rows are selected or deselected via the select-all checkbox.
+  @Output() selectAllEvent: EventEmitter<SelectionState> = new EventEmitter<SelectionState>();
+  `;
+
+  tableSelectionModels: string = `
+  export interface RowSelectionEvent extends SelectionState {
+    /**
+     * The current row that was targeted for selection
+     */
+    currentRow: {
+      /**
+       * The entire data in the row
+       */
+      data: object;
+      /**
+       * Whether or not this row was selected (\`true\`) or deselected (\`false\`)
+       */
+      selected: boolean;
+    };
+  }
+
   export interface SelectionState {
     /**
-     * Defines the current mode of selection. 'selection' will add items to 'selectedRows'
-     * and 'deselection' will add items to 'deselectedRows'.
+     * The current deselected rows; if \`selectionMode\` is \`selection\` then this will always be an empty array
+     */
+    deselectedRows?: any[];
+
+    /**
+     * Defines the current mode of selection. \`selection\` will add items to \`selectedRows\`
+     * and \`deselection\` will add items to \`deselectedRows\`.
      *
-     * If in 'deselection' mode, the UI toggles all checkboxes to true. Items instead will be added to 'deselectedRows'
+     * If in \`deselection\` mode, the UI toggle all checkboxes to true. Items instead will be added to \`deselectedRows\`
      * because they're being removed from the selection.
      */
     selectionMode: SelectionMode;
 
     /**
-     * The current deselected rows; if 'selectionMode' is 'selection' then this will always be an empty array
-     */
-    deselectedRows?: any[];
-
-    /**
-     * The current selected rows; if 'selectionMode' is 'deselection' then this will always be an empty array
+     * The current selected rows; if \`selectionMode\` is \`deselection\` then this will always be an empty array
      */
     selectedRows?: any[];
   }
+  `;
 
-  export enum SelectionMode {
-    selection = 'selection',
-    deselection = 'deselection'
+  tableSelectionExample_html: string = `
+  <go-table
+    [tableConfig]="tableConfig"
+    (rowSelectionEvent)="tableRowEvent($event)"
+    (selectAllEvent)="selectAllEvent($event)">
+    <!-- Table rows markup --!>
+  </go-table>
+  `;
+
+  tableSelectionExample_ts: string = `
+  tableRowEvent(rowEvent: RowSelectionEvent): void {
+    // Do something with the rowEvent
+  }
+
+  selectAllEvent(selectionState: SelectionState): void {
+    // Do something with the selectionState
   }
   `;
 
@@ -190,15 +227,28 @@ export class TableSelectionComponent {
     this.toasterService.toastInfo({ header: 'Row Event', message: 'Selection Mode: ' + rowEvent.selectionMode + '. ' }, 6000);
     this.toasterService.toastInfo({ header: 'Row Event', message: 'Selected Row Count: ' + rowEvent.selectedRows.length + '. ' }, 6000);
     this.toasterService.toastInfo({ header: 'Row Event', message: 'Deselected Row Count: ' + rowEvent.deselectedRows.length + '. ' }, 6000);
-    if (rowEvent.currentRow) {
-      this.toasterService.toastInfo(
-        {
-          header: 'Row Event',
-          message: `Current Row Id: ${rowEvent.currentRow.data['id']}, ${rowEvent.currentRow.selected ? 'selected' : 'deselected'}.`
-        },
-        6000
-      );
-    }
+    this.toasterService.toastInfo(
+      {
+        header: 'Row Event',
+        message: `Current Row Id: ${rowEvent.currentRow.data['id']}, ${rowEvent.currentRow.selected ? 'selected' : 'deselected'}.`
+      },
+      6000
+    );
+  }
+
+  selectAllEvent(selectionState: SelectionState): void {
+    this.toasterService.toastInfo(
+      { header: 'Select All Event', message: 'Selection Mode: ' + selectionState.selectionMode + '. ' },
+      6000
+    );
+    this.toasterService.toastInfo(
+      { header: 'Select All Event', message: 'Selected Row Count: ' + selectionState.selectedRows.length + '. ' },
+      6000
+    );
+    this.toasterService.toastInfo(
+      { header: 'Select All Event', message: 'Deselected Row Count: ' + selectionState.deselectedRows.length + '. ' },
+      6000
+    );
   }
 
   interactiveTableState(): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #684 

## What is the new behavior?
The `go-table` now emits an event from the `rowSelectionEvent` output when the checkbox to select/deselect all rows is clicked, rather than just when individual rows are selected/deselected.

This will enable components that need to be aware of the table's selection state when the checkbox to select/deselect all rows is clicked to do so.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
