### PR TITLE
Support for 'target' element in app drawer config

### DIFF
--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
@@ -1,8 +1,8 @@
 <!-- External Link -->
 <a
   class="go-panel"
-  target="_blank"
-  rel="noreferrer"
+  [target]="target ? target : '_blank'"
+  [rel]="target ? target : 'noreferrer'"
   [ngClass]="panelClasses()"
   [attr.href]="externalLink"
   *ngIf="externalLink; else noLink"

--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.ts
@@ -13,6 +13,7 @@ export class GoPanelComponent {
   @Input() icon: string;
   @Input() externalLink: string;
   @Input() panelContent: string;
+  @Input() target: string;
 
   @Output() action: EventEmitter<void> = new EventEmitter<void>();
 

--- a/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
+++ b/projects/go-lib/src/lib/components/go-side-nav/go-side-nav/go-side-nav.component.html
@@ -33,6 +33,7 @@
                   [icon]="appDrawerItem.icon"
                   [panelContent]="appDrawerItem.displayName"
                   [externalLink]="appDrawerItem.url"
+                  [target]="appDrawerItem.target"
                   (click)="appDrawerActionSheet.triggerAS()">
         </go-panel>
       </ng-container>

--- a/projects/go-lib/src/lib/components/go-side-nav/nav-app-drawer.model.ts
+++ b/projects/go-lib/src/lib/components/go-side-nav/nav-app-drawer.model.ts
@@ -8,6 +8,7 @@ interface NavAppDrawerItem {
   displayName: string;
   icon: string;
   url: string;
+  target?: string;
 }
 
 export { NavAppDrawer, NavAppDrawerItem };

--- a/projects/go-style-guide/src/app/app.component.ts
+++ b/projects/go-style-guide/src/app/app.component.ts
@@ -60,7 +60,8 @@ export class AppComponent {
       {
         displayName: 'GitHub',
         icon: 'code',
-        url: 'https://github.com/'
+        url: 'https://github.com/',
+        target: 'github'
       },
       {
         displayName: 'Go Design',

--- a/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.html
@@ -42,8 +42,9 @@
         <h4 class="go-heading-4">externalLink</h4>
         <p class="go-body-copy">
           This binding allows the implementer to target a route outside of Angular.
-          This should not be used in conjuction with a <code class="code-block--inline">routerLink</code>.
-          The link will open in a new tab.
+          This should not be used in conjunction with a <code class="code-block--inline">routerLink</code>.
+          The link will open in a new tab by default. The <code class="code-block--inline">target</code> may be changed
+          using the <code class="code-block--inline">target</code> binding.
         </p>
       </div>
 
@@ -58,6 +59,14 @@
         <h4 class="go-heading-4">action</h4>
         <p class="go-body-copy">
           This is an event that is emitted from the panel when a user clicks on the panel.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100">
+        <h4 class="go-heading-4">target (optional)</h4>
+        <p class="go-body-copy">
+          This optional binding sets the target for an external link. By default, the value is
+          <code class="code-block--inline">_blank</code> which will open the link in a new tab.
         </p>
       </div>
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.ts
@@ -14,6 +14,7 @@ export class ActionSheetPanelDocsComponent {
   @Input() icon: string;
   @Input() externalLink: string;
   @Input() panelContent: string;
+  @Input() target: string = '_blank';
 
   @Output() action: EventEmitter<void> = new EventEmitter<void>();
   `;

--- a/projects/go-style-guide/src/app/features/ui-kit/components/layout-docs/components/layout-app-drawer/layout-app-drawer.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/layout-docs/components/layout-app-drawer/layout-app-drawer.component.html
@@ -52,7 +52,11 @@
           <code class="code-block--inline">NavAppDrawerItem.icon</code> - icon for application (material theme icon)
         </p>
         <p>
-          <code class="code-block--inline">NavAppDrawerItem.url</code> - url for application, will open in a new tab
+          <code class="code-block--inline">NavAppDrawerItem.url</code> - url for application
+        </p>
+        <p>
+          <code class="code-block--inline">NavAppDrawerItem.target</code> - (optional) target for url. Default value is
+          <code class="code-block--inline">_blank</code> which will open a new tab.
         </p>
       </div>
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/layout-docs/components/layout-app-drawer/layout-app-drawer.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/layout-docs/components/layout-app-drawer/layout-app-drawer.component.ts
@@ -18,6 +18,7 @@ export class LayoutAppDrawerComponent {
     displayName: string;
     icon: string;
     url: string;
+    target?: string;
   }
 
   export { NavAppDrawer, NavAppDrawerItem };
@@ -33,7 +34,8 @@ export class LayoutAppDrawerComponent {
       {
         displayName: 'GitHub',
         icon: 'code',
-        url: 'https://github.com/'
+        url: 'https://github.com/',
+        target: 'github'
       },
       {
         displayName: 'Go Design',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Current app drawer config does not support a target for external links

Resolves https://github.com/mobi/goponents/issues/696

## What is the new behavior?

Optional config item added to support `target` for app drawer. 

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
