### PR TITLE
Max and min length bindings for goInput - 691

### DIFF
--- a/projects/go-lib/src/lib/components/go-input/go-input.component.html
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.html
@@ -11,7 +11,9 @@
          [ngClass]="{'go-form__input--error': control?.errors?.length, 'go-form__input--dark': theme === 'dark'}"
          [type]="inputType"
          [placeholder]="placeholder"
-         [formControl]="control">
+         [formControl]="control"
+         [maxlength]="maxlength"
+         [minlength]="minlength">
 
   <go-hint *ngFor="let hint of hints" [message]="hint" [theme]="theme"></go-hint>
 

--- a/projects/go-lib/src/lib/components/go-input/go-input.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.spec.ts
@@ -33,4 +33,18 @@ describe('GoInputComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('ngOnInit()', () => {
+    it('sets default minlength if no minlength is specified', () => {
+      fixture.detectChanges();
+
+      expect(component.minlength).toBe(0);
+    });
+
+    it('sets default maxlength if no maxlength is specified', () => {
+      fixture.detectChanges();
+
+      expect(component.maxlength).toBe(524288);
+    });
+  });
 });

--- a/projects/go-lib/src/lib/components/go-input/go-input.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.spec.ts
@@ -35,16 +35,21 @@ describe('GoInputComponent', () => {
   });
 
   describe('ngOnInit()', () => {
-    it('sets default minlength if no minlength is specified', () => {
-      fixture.detectChanges();
+    it('sets minlength to 0 if minlength is greater than maxlength', () => {
+      component.minlength = 10;
+      component.maxlength = 8;
+
+      component.ngOnInit();
 
       expect(component.minlength).toBe(0);
-    });
+    })
+      
+    it('sets maxlength to 524288 if maxlength is greater than 524288', () => {
+      component.maxlength = 524290;
 
-    it('sets default maxlength if no maxlength is specified', () => {
-      fixture.detectChanges();
+      component.ngOnInit();
 
       expect(component.maxlength).toBe(524288);
-    });
+    })
   });
 });

--- a/projects/go-lib/src/lib/components/go-input/go-input.component.ts
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.ts
@@ -12,6 +12,8 @@ export class GoInputComponent implements OnInit {
 
   @Input() control: FormControl;
   @Input() key: string;
+  @Input() maxlength: number = 524288;
+  @Input() minlength: number = 0;
   @Input() hints: string[];
   @Input() inputType: string = 'text';
   @Input() label: string;
@@ -22,5 +24,14 @@ export class GoInputComponent implements OnInit {
 
   ngOnInit(): void {
     this.id = this.key || generateId(this.label, 'input');
+
+    if (this.minlength > this.maxlength){
+      this.minlength = 0;
+    }
+
+    if (this.maxlength > 524288)
+    {
+      this.maxlength = 524288
+    }
   }
 }

--- a/projects/go-lib/src/lib/components/go-input/go-input.component.ts
+++ b/projects/go-lib/src/lib/components/go-input/go-input.component.ts
@@ -25,12 +25,11 @@ export class GoInputComponent implements OnInit {
   ngOnInit(): void {
     this.id = this.key || generateId(this.label, 'input');
 
-    if (this.minlength > this.maxlength){
+    if (this.minlength > this.maxlength) {
       this.minlength = 0;
     }
 
-    if (this.maxlength > 524288)
-    {
+    if (this.maxlength > 524288) {
       this.maxlength = 524288
     }
   }

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/input-docs/input-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/input-docs/input-docs.component.html
@@ -351,4 +351,52 @@
 
     </div>
   </go-card>
+
+  <go-card id="form-length-type" class="go-column go-column--100">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Component Maxlength And Minlength</h2>
+      <go-copy cardId="form-length-type" goCopyCardLink></go-copy>
+    </ng-container>
+    <div class="go-container" go-card-content>
+
+      <div class="go-column go-column--100">
+        <p class="go-body-copy">
+          The maxlength and minlength properties of the input can be set via
+          <code class="code-block--inline">@Input() maxlength: number;</code>
+          and the <code class="code-block--inline">@Input() minlength: number;</code> bindings.
+          By default the <code class="code-block--inline">maxlength</code> is set to 
+          <code class="code-block--inline">524288</code> and the 
+          <code class="code-block--inline">minlength</code> is set to <code class="code-block--inline">0</code>.
+          Please note that the <code class="code-block--inline">minlength</code> property would come into
+          effect when the corresponding form containing the input component would be submitted.
+        </p>
+        <p class="go-body-copy go-body-copy--no-margin">
+          In the example below we show how to use <code class="code-block--inline">maxlength</code>
+          and <code class="code-block--inline">minlength</code>.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <div class="go-container">
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">View</h4>
+            <go-input
+              [control]="name"
+              label="Name"
+              maxlength="10"
+              minlength="5">
+            </go-input>
+          </div>
+          <div class="go-column go-column--50">
+            <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+            <code
+              [highlight]="basicLengthExample"
+              class="code-block--no-bottom-margin">
+            </code>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </go-card>
 </section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/input-docs/input-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/input-docs/input-docs.component.html
@@ -352,10 +352,10 @@
     </div>
   </go-card>
 
-  <go-card id="form-length-type" class="go-column go-column--100">
+  <go-card id="form-input-max-min-length" class="go-column go-column--100">
     <ng-container go-card-header>
       <h2 class="go-heading-2 go-heading--no-wrap">Component Maxlength And Minlength</h2>
-      <go-copy cardId="form-length-type" goCopyCardLink></go-copy>
+      <go-copy cardId="form-input-max-min-length" goCopyCardLink></go-copy>
     </ng-container>
     <div class="go-container" go-card-content>
 
@@ -369,10 +369,6 @@
           <code class="code-block--inline">minlength</code> is set to <code class="code-block--inline">0</code>.
           Please note that the <code class="code-block--inline">minlength</code> property would come into
           effect when the corresponding form containing the input component would be submitted.
-        </p>
-        <p class="go-body-copy go-body-copy--no-margin">
-          In the example below we show how to use <code class="code-block--inline">maxlength</code>
-          and <code class="code-block--inline">minlength</code>.
         </p>
       </div>
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/input-docs/input-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/input-docs/input-docs.component.ts
@@ -84,8 +84,8 @@ export class InputDocsComponent implements OnInit {
   <go-input
     [control]="name"
     label="Your Name"
-    maxlength="10"
-    minlength="5">
+    [maxlength]="10"
+    [minlength]="5">
   </go-input>
   `;
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/input-docs/input-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/form-docs/components/input-docs/input-docs.component.ts
@@ -79,6 +79,16 @@ export class InputDocsComponent implements OnInit {
     // Use this.lastName.enable(); to re-enable the input.
   }
   `;
+
+  basicLengthExample: string = `
+  <go-input
+    [control]="name"
+    label="Your Name"
+    maxlength="10"
+    minlength="5">
+  </go-input>
+  `;
+
   basicPlaceholderExample: string = `
   <go-input
     [control]="name"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [ ] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Right now, goponents does not provide a way to set maxlength and minlength for `go-input`. This PR includes necessary changes (both code-wise and documentation) for the same.

Resolves #691 

## What is the new behavior?
Developers can now set the maxlength and minlength for `go-input`

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
