### PR TITLE
Add closeOnClick input to go-panel

### DIFF
--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.html
@@ -6,7 +6,7 @@
   [ngClass]="panelClasses()"
   [attr.href]="externalLink"
   *ngIf="externalLink; else noLink"
-  (click)="closeActionSheet()">
+  (click)="panelClicked()">
   <span class="go-panel__title">
     <span *ngIf="icon" class="go-panel__icon material-icons">{{icon}}</span>
     <span class="go-panel__title-text" [innerHtml]="panelContent"></span>

--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.spec.ts
@@ -44,22 +44,31 @@ describe('GoPanelComponent', () => {
       expect(component.action.emit).toHaveBeenCalled();
     });
 
-    it('should close the action sheet', () => {
-      parentComponent.showContent = true;
+    it('should call panelClicked', () => {
+      spyOn(component, 'panelClicked');
 
       component.handleAction();
 
-      expect(parentComponent.showContent).toBeFalsy();
+      expect(component.panelClicked).toHaveBeenCalled();
     });
   });
 
-  describe('closeActionSheet', () => {
-    it('should set parent action sheet\'s showContent to false', () => {
+  describe('panelClicked', () => {
+    it('should set parent action sheet\'s showContent to false if closeOnClick is true', () => {
       parentComponent.showContent = true;
 
-      component.closeActionSheet();
+      component.panelClicked();
 
       expect(parentComponent.showContent).toBeFalsy();
+    });
+
+    it('should not set parent action sheet\'s showContent to false if closeOnClick is false', () => {
+      parentComponent.showContent = true;
+      component.closeOnClick = false;
+
+      component.panelClicked();
+
+      expect(parentComponent.showContent).toBe(true);
     });
   });
 });

--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.spec.ts
@@ -56,6 +56,7 @@ describe('GoPanelComponent', () => {
   describe('panelClicked', () => {
     it('should set parent action sheet\'s showContent to false if closeOnClick is true', () => {
       parentComponent.showContent = true;
+      component.closeOnClick = true;
 
       component.panelClicked();
 

--- a/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.ts
+++ b/projects/go-lib/src/lib/components/go-action-sheet/go-panel/go-panel.component.ts
@@ -14,6 +14,7 @@ export class GoPanelComponent {
   @Input() externalLink: string;
   @Input() panelContent: string;
   @Input() target: string;
+  @Input() closeOnClick: boolean = true;
 
   @Output() action: EventEmitter<void> = new EventEmitter<void>();
 
@@ -28,10 +29,12 @@ export class GoPanelComponent {
 
   handleAction(): void {
     this.action.emit();
-    this.closeActionSheet();
+    this.panelClicked();
   }
 
-  closeActionSheet(): void {
-    this.parent.showContent = false;
+  panelClicked(): void {
+    if (this.closeOnClick) {
+      this.parent.showContent = false;
+    }
   }
 }

--- a/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.html
@@ -5,7 +5,7 @@
       <go-copy cardId="usage" goCopyCardLink></go-copy>
     </ng-container>
     <div class="go-container" go-card-content>
-      
+
       <div class="go-column go-column--100">
         <p class="go-body-copy">The <code class="code-block--inline">go-panel</code> should be used in conjuction with the Action Sheet.</p>
       </div>
@@ -30,14 +30,14 @@
           Ideally, this should only be used for the first panel in an action sheet.
         </p>
       </div>
-      
+
       <div class="go-column go-column--100">
         <h4 class="go-heading-4">icon</h4>
         <p class="go-body-copy">
           The Material Icons string for an icon. If not passed, the space for the icon goes away.
         </p>
       </div>
-      
+
       <div class="go-column go-column--100">
         <h4 class="go-heading-4">externalLink</h4>
         <p class="go-body-copy">
@@ -51,10 +51,10 @@
       <div class="go-column go-column--100">
         <h4 class="go-heading-4">panelContent</h4>
         <p class="go-body-copy">
-          This binding is the content of the panel. HTML can be passed into this. 
+          This binding is the content of the panel. HTML can be passed into this.
         </p>
       </div>
-      
+
       <div class="go-column go-column--100">
         <h4 class="go-heading-4">action</h4>
         <p class="go-body-copy">
@@ -67,6 +67,14 @@
         <p class="go-body-copy">
           This optional binding sets the target for an external link. By default, the value is
           <code class="code-block--inline">_blank</code> which will open the link in a new tab.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100">
+        <h4 class="go-heading-4">closeOnClick</h4>
+        <p class="go-body-copy">
+          This determines whether the action sheet will close when the panel is clicked.
+          Defaults to <code class="code-block--inline">true</code>.
         </p>
       </div>
 
@@ -300,53 +308,98 @@
       </div>
     </div>
   </go-card>
-</section>
 
-<go-card class="go-column go-column--100" id="content-projection">
-  <ng-container go-card-header>
-    <h2 class="go-heading-2 go-heading--no-wrap">Content Projection</h2>
-    <go-copy cardId="content-projection" goCopyCardLink></go-copy>
-  </ng-container>
-  <div go-card-content>
-    <div class="go-container">
-      <div class="go-column--100 go-column go-column--no-padding">
-        <p class="go-body-copy">
-          Content can be projected into a <code class="code-block--inline">go-panel</code>
-          to enable more complex structure and stylings. Content projection only works, however,
-          when nothing is passed to the <code class="code-block--inline">panelContent</code>
-          or <code class="code-block--inline">externalLink</code> inputs.
-        </p>
-      </div>
-      <div class="go-column go-column--50 go-column--no-padding">
-        <h4 class="go-heading-4 go-heading--underlined">Code</h4>
-        <code [highlight]="contentProjectionHtml"></code>
-      </div>
-      <div class="go-column go-column--50 go-column--no-padding go-column--collapse">
-        <h4 class="go-heading-4 go-heading--underlined">View</h4>
-        <go-action-sheet>
-          <ng-container go-action-sheet__button>
-            <go-button>
-              Sheet With Content Projection
-            </go-button>
-          </ng-container>
-          <ng-container go-action-sheet-content>
-            <go-panel>
-              <ol class="go-ordered-list">
-                <li class="go-ordered-list__item">One</li>
-                <li class="go-ordered-list__item">Two</li>
-                <li class="go-ordered-list__item">Three</li>
-              </ol>
-            </go-panel>
-            <go-panel>
-              <ol class="go-ordered-list">
-                <li class="go-ordered-list__item">Four</li>
-                <li class="go-ordered-list__item">Five</li>
-                <li class="go-ordered-list__item">Six</li>
-              </ol>
-            </go-panel>
-          </ng-container>
-        </go-action-sheet>
+  <go-card class="go-column go-column--100" id="close-on-click" #router>
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Close On Click</h2>
+      <go-copy cardId="close-on-click" goCopyCardLink></go-copy>
+    </ng-container>
+    <div go-card-content>
+      <div class="go-container">
+        <div class="go-column--100 go-column go-column--no-padding">
+          <p class="go-body-copy">
+            This example shows an instance where the panels do not close the action sheet when clicked.
+          </p>
+        </div>
+        <div class="go-column go-column--50 go-column--no-padding">
+          <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+          <code [highlight]="closeOnClickHtml"></code>
+        </div>
+        <div class="go-column go-column--50 go-column--no-padding go-column--collapse">
+          <h4 class="go-heading-4 go-heading--underlined">View</h4>
+          <go-action-sheet>
+            <ng-container go-action-sheet__button>
+              <go-button>
+                Actions Sheet
+              </go-button>
+            </ng-container>
+            <ng-container go-action-sheet-content>
+              <go-panel
+                panelContent="Home"
+                [closeOnClick]="false">
+              </go-panel>
+              <go-panel
+                (action)="toast()"
+                panelContent="Toast Me"
+                [closeOnClick]="false">
+              </go-panel>
+              <go-panel
+                panelContent="Settings"
+                [closeOnClick]="false">
+              </go-panel>
+            </ng-container>
+          </go-action-sheet>
+        </div>
       </div>
     </div>
-  </div>
-</go-card>
+  </go-card>
+
+  <go-card class="go-column go-column--100" id="content-projection">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Content Projection</h2>
+      <go-copy cardId="content-projection" goCopyCardLink></go-copy>
+    </ng-container>
+    <div go-card-content>
+      <div class="go-container">
+        <div class="go-column--100 go-column go-column--no-padding">
+          <p class="go-body-copy">
+            Content can be projected into a <code class="code-block--inline">go-panel</code>
+            to enable more complex structure and stylings. Content projection only works, however,
+            when nothing is passed to the <code class="code-block--inline">panelContent</code>
+            or <code class="code-block--inline">externalLink</code> inputs.
+          </p>
+        </div>
+        <div class="go-column go-column--50 go-column--no-padding">
+          <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+          <code [highlight]="contentProjectionHtml"></code>
+        </div>
+        <div class="go-column go-column--50 go-column--no-padding go-column--collapse">
+          <h4 class="go-heading-4 go-heading--underlined">View</h4>
+          <go-action-sheet>
+            <ng-container go-action-sheet__button>
+              <go-button>
+                Sheet With Content Projection
+              </go-button>
+            </ng-container>
+            <ng-container go-action-sheet-content>
+              <go-panel>
+                <ol class="go-ordered-list">
+                  <li class="go-ordered-list__item">One</li>
+                  <li class="go-ordered-list__item">Two</li>
+                  <li class="go-ordered-list__item">Three</li>
+                </ol>
+              </go-panel>
+              <go-panel>
+                <ol class="go-ordered-list">
+                  <li class="go-ordered-list__item">Four</li>
+                  <li class="go-ordered-list__item">Five</li>
+                  <li class="go-ordered-list__item">Six</li>
+                </ol>
+              </go-panel>
+            </ng-container>
+          </go-action-sheet>
+        </div>
+      </div>
+    </div>
+  </go-card>
+</section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/action-sheet-docs/components/action-sheet-panel-docs/action-sheet-panel-docs.component.ts
@@ -15,6 +15,7 @@ export class ActionSheetPanelDocsComponent {
   @Input() externalLink: string;
   @Input() panelContent: string;
   @Input() target: string = '_blank';
+  @Input() closeOnClick: boolean = true;
 
   @Output() action: EventEmitter<void> = new EventEmitter<void>();
   `;
@@ -127,6 +128,31 @@ export class ActionSheetPanelDocsComponent {
   </go-action-sheet>
   `;
 
+  closeOnClickHtml: string = `
+  <go-action-sheet>
+    <ng-container go-action-sheet__button>
+      <go-button>
+        Actions Sheet
+      </go-button>
+    </ng-container>
+    <ng-container go-action-sheet-content>
+      <go-panel
+        panelContent="Home"
+        [closeOnClick]="false">
+      </go-panel>
+      <go-panel
+        (action)="toast()"
+        panelContent="Toast Me"
+        [closeOnClick]="false">
+      </go-panel>
+      <go-panel
+        panelContent="Settings"
+        [closeOnClick]="false">
+      </go-panel>
+    </ng-container>
+  </go-action-sheet>
+  `;
+
   contentProjectionHtml: string = `
     <go-action-sheet>
       <ng-container go-action-sheet__button>
@@ -159,7 +185,6 @@ export class ActionSheetPanelDocsComponent {
   ) {
     this.subNavService.pageTitle = 'Action Sheet Panel';
     this.subNavService.linkToSource = 'https://github.com/mobi/goponents/tree/dev/projects/go-lib/src/lib/components/go-action-sheet/go-panel';
-
   }
 
   toast(): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #700 

## What is the new behavior?
This adds a `closeOnClick` input to the `go-panel` which determines whether clicking the panel closes its parent action-sheet. The input is set to `true` by default.

This was needed because there are some cases where we do not want action-sheets to close when the `go-panel`s within them are clicked.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
