### PR TITLE
Changes to Closing Modals

### DIFF
--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.html
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.html
@@ -11,6 +11,7 @@
       <go-icon-button
         buttonIcon="close"
         class="go-modal__close"
+        *ngIf="showCloseIcon"
         (handleClick)="closeModal()">
       </go-icon-button>
     </div>

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
@@ -109,12 +109,49 @@ describe('GoModalComponent', () => {
 
       expect(component.modalSize).toEqual(component.defaultModalSize);
     });
+
+    it('sets closeWithBackdrop to false if not passed in', () => {
+      component.currentComponent = new GoModalItem(GoTestModalHostComponent, {  });
+      component.closeWithBackdrop = true;
+
+      component.loadComponent();
+
+      expect(component.closeWithBackdrop).toEqual(false);
+    });
+
+    it('sets closeWithBackdrop to true if passed in', () => {
+      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { closeWithBackdrop: true });
+      component.closeWithBackdrop = false;
+
+      component.loadComponent();
+
+      expect(component.closeWithBackdrop).toEqual(true);
+    });
+
+    it('sets showCloseIcon to true if not passed in', () => {
+      component.currentComponent = new GoModalItem(GoTestModalHostComponent, {  });
+      component.showCloseIcon = false;
+
+      component.loadComponent();
+
+      expect(component.showCloseIcon).toEqual(true);
+    });
+
+    it('sets closeWithBackdrop to false if passed in', () => {
+      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { showCloseIcon: false });
+      component.showCloseIcon = true;
+
+      component.loadComponent();
+
+      expect(component.showCloseIcon).toEqual(false);
+    });
   });
 
   describe('backdropClick', () => {
     beforeEach(() => {
       spyOn(component, 'closeModal');
 
+      component.closeWithBackdrop = true;
       component.goModal = <any> {
         nativeElement: '<test-element></test-element>'
       };
@@ -136,6 +173,13 @@ describe('GoModalComponent', () => {
       component.backdropClick(<any> { target: component.goModal.nativeElement });
 
       expect(component.closeModal).toHaveBeenCalled();
+    });
+
+    it('does not close the modal if closeWithBackdrop is false', () => {
+      component.closeWithBackdrop = false;
+      component.backdropClick(<any> { target: component.goModal.nativeElement });
+
+      expect(component.closeModal).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
@@ -20,11 +20,13 @@ import { GoModalService } from './go-modal.service';
 export class GoModalComponent implements OnInit {
   readonly defaultModalSize: 'lg' | 'xl' = 'lg';
 
+  closeWithBackdrop: boolean = false;
   currentComponent: any;
   modalTitle: string;
   modalSize: 'lg' | 'xl' = this.defaultModalSize;
   noContentPadding: boolean = false;
   opened: boolean = false;
+  showCloseIcon: boolean = true;
 
   @ViewChild(GoModalDirective, { static: true }) goModalHost: GoModalDirective;
   @ViewChild('goModal', { static: true }) goModal: ElementRef<HTMLElement>;
@@ -73,8 +75,14 @@ export class GoModalComponent implements OnInit {
       this.modalSize = this.defaultModalSize;
     }
 
+    // Set close with backdrop if provided
+    this.closeWithBackdrop = componentRef.instance['closeWithBackdrop'] === true ? true : false;
+
     // set content padding if provided
     this.noContentPadding = componentRef.instance['noContentPadding'];
+
+    // set close icon if provided
+    this.showCloseIcon = componentRef.instance['showCloseIcon'] === false ? false : true;
   }
 
   /**
@@ -83,7 +91,7 @@ export class GoModalComponent implements OnInit {
    * @param $event - Click event
    */
   backdropClick($event: MouseEvent): void {
-    if ($event && this.goModal.nativeElement === $event.target) {
+    if ($event && this.closeWithBackdrop && this.goModal.nativeElement === $event.target) {
       this.closeModal();
     }
   }

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.html
@@ -128,6 +128,63 @@
     </div>
   </go-card>
 
+  <go-card class="go-column go-column--100" id="modal-backdrop">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Modal Backdrop</h2>
+      <go-copy cardId="modal-backdrop" goCopyCardLink></go-copy>
+    </ng-container>
+    <div class="go-container" go-card-content>
+
+      <div class="go-column go-column--100">
+        <p class="go-body-copy go-body-copy--no-margin">
+          By default clicking on the backdrop behind the modal will not close the modal. If you wish to enable closing
+          the modal by clicking on the backdrop the <code class="code-block--inline">closeWithBackdrop</code> binding can
+          be used to enable it.
+        </p>
+      </div>
+
+      <div class="go-column go-column--75">
+        <h4 class="go-heading-4">Code</h4>
+        <code [highlight]="ex_ModalDocsCloseWithBackdrop"></code>
+      </div>
+
+      <div class="go-column go-column--25">
+        <h4 class="go-heading-4">View</h4>
+        <go-button (handleClick)="openCloseWithBackdropModal()">Click Me</go-button>
+      </div>
+
+    </div>
+  </go-card>
+
+  <go-card class="go-column go-column--100" id="modal-close-icon">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Modal Close Icon</h2>
+      <go-copy cardId="modal-close-icon" goCopyCardLink></go-copy>
+    </ng-container>
+    <div class="go-container" go-card-content>
+
+      <div class="go-column go-column--100">
+        <p class="go-body-copy go-body-copy--no-margin">
+          By default there is a close icon in the upper right corner of a modal. In certain cases where
+          a response is required by a user we might want to remove this icon to force a user to make a decision between
+          a set of choices. This icon can be disabled through the <code class="code-block--inline">showCloseIcon</code>
+          binding.
+        </p>
+      </div>
+
+      <div class="go-column go-column--75">
+        <h4 class="go-heading-4">Code</h4>
+        <code [highlight]="ex_ModalDocsNoCloseIcon"></code>
+      </div>
+
+      <div class="go-column go-column--25">
+        <h4 class="go-heading-4">View</h4>
+        <go-button (handleClick)="openNoCloseIconModal()">Click Me</go-button>
+      </div>
+
+    </div>
+  </go-card>
+
   <go-card class="go-column go-column--100" id="sizes">
     <ng-container go-card-header>
       <h2 class="go-heading-2 go-heading--no-wrap">Modal Sizes</h2>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
@@ -88,6 +88,23 @@ export class ModalDocsComponent {
   });
   `;
 
+  ex_ModalDocsCloseWithBackdrop: string = `
+  this.goModalService.openModal(ModalTestComponent, {
+    modalTitle: 'Close With Backdrop Example',
+    content: 'You can close this modal by clicking on the page outside of the modal',
+    closeWithBackdrop: true
+  });
+  `;
+
+  ex_ModalDocsNoCloseIcon: string = `
+  this.goModalService.openModal(ModalTestComponent, {
+    modalTitle: 'Close With Backdrop Example',
+    content: 'The only way to close this modal is by clicking outside of the modal on the backdrop',
+    closeWithBackdrop: true,
+    showCloseIcon: false
+  });
+  `;
+
   linkToSource: string = 'https://github.com/mobi/goponents/tree/dev/projects/go-lib/src/lib/components/go-modal';
 
   constructor(private goModalService: GoModalService) { }
@@ -109,6 +126,23 @@ export class ModalDocsComponent {
       modalTitle: 'No Padding Example',
       content: 'This area has no padding',
       noContentPadding: true
+    });
+  }
+
+  openCloseWithBackdropModal(): void {
+    this.goModalService.openModal(ModalTestComponent, {
+      modalTitle: 'Close With Backdrop Example',
+      content: 'You can close this modal by clicking on the page outside of the modal',
+      closeWithBackdrop: true
+    });
+  }
+
+  openNoCloseIconModal(): void {
+    this.goModalService.openModal(ModalTestComponent, {
+      modalTitle: 'Close With Backdrop Example',
+      content: 'The only way to close this modal is by clicking outside of the modal on the backdrop',
+      closeWithBackdrop: true,
+      showCloseIcon: false
     });
   }
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Resolves #680 

## What is the new behavior?
Defaults clicking outside of a modal to not close the modal. This can be changed through a binding provided on the modal.

Provides a binding on modals to individually hide the close modal icon on modals where a decision is required to be made


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

There are no breaking changes, but this does change the ux of how Modals work, so it should be documented here that clicking on the backdrop of a modal will no longer close it unless the `closeWithBackdrop` is set to true on the modal.
