### PR TITLE
[Bug] Enforce Table Column Width

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table.component.html
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.html
@@ -59,7 +59,8 @@
           <th *ngFor="let col of columns"
               class="go-table__head-column"
               (click)="toggleSort(col.sortable, col.field)"
-              [ngClass]="{ 'go-table__head--sortable': col.sortable !== undefined ? col.sortable : localTableConfig.sortable }">
+              [ngClass]="{ 'go-table__head--sortable': col.sortable !== undefined ? col.sortable : localTableConfig.sortable }"
+              [ngStyle]="{ 'min-width': col.width + 'px' }">
             <div class="go-table__head-content">
               <ng-container *ngIf="!col.goTableHead; else columnHeaderOutlet">
                 {{ col.title || col.field }}
@@ -114,9 +115,8 @@
             <td *ngFor="let col of columns"
                 class="go-table__body-column"
                 [ngClass]="{ 'go-table__body-row--expanded': item.showDetails }"
-                [ngStyle]="{ 'vertical-align': col.alignment }"
-                [@tableRowBorderAnim]="item.showDetails ? 'open' : 'close'"
-                [attr.width]="col.width">
+                [ngStyle]="{ 'vertical-align': col.alignment, 'min-width': col.width + 'px' }"
+                [@tableRowBorderAnim]="item.showDetails ? 'open' : 'close'">
               <ng-container *ngIf="!col.goTableCell; else columnCellOutlet">
                 {{ col.getFieldData(item) }}
               </ng-container>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-column-docs/table-column-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-column-docs/table-column-docs.component.html
@@ -71,7 +71,7 @@
       <div class="go-column go-column--100 go-column--no-padding">
         <h4 class="go-heading-4">width</h4>
         <p class="go-body-copy go-body-copy--no-margin">
-          This binding sets the width for column. The value must be in pixels.
+          This binding sets the minimum possible width for column. The value must be in pixels.
         </p>
       </div>
 

--- a/projects/go-tester/src/app/components/test-page-1/test-page-1.component.html
+++ b/projects/go-tester/src/app/components/test-page-1/test-page-1.component.html
@@ -83,7 +83,7 @@
     <go-table-column field="name.last" [sortable]="true" title="Last Name"></go-table-column>
     <go-table-column field="email" [sortable]="true" title="Email"></go-table-column>
     <go-table-column field="gender" title="Gender"></go-table-column>
-    <go-table-column field="ip_address" title="IP Address"></go-table-column>
+    <go-table-column field="ip_address" title="IP Address" width="400"></go-table-column>
 
     <ng-container #goTableChildRows>
       <go-table-child-column field="id"></go-table-child-column>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
~~Tests for the changes have been added~~
~~Docs have been added or updated~~

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Currently we set the `width` property on the table cell when assigned one. That approach does not constrain the width of the column to the desired size if the content within the table is too great for its container.

Resolves #707 

## What is the new behavior?
Now, the `min-width` property is set instead of the `width`. This allows for stricter control over table column widths. Using `min-width` will allow the column to expand if the space is available, but it will not shrink beyond the specified limit regardless of other table content.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
