### PR TITLE
[Chore] Modal & Off Canvas Type Improvements

### DIFF
--- a/projects/go-lib/src/lib/components/go-modal/go-modal-options.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal-options.ts
@@ -1,0 +1,24 @@
+export class GoModalOptions {
+  readonly defaultModalSize?: 'lg' | 'xl' = 'lg';
+
+  /**
+   * Whether or not the modal closes when the user clicks on the backdrop
+   */
+  closeWithBackdrop?: boolean = false;
+  /**
+   * The title for the modal.
+   */
+  modalTitle?: string;
+  /**
+   * The general size for the modal.
+   */
+  modalSize?: 'lg' | 'xl' = this.defaultModalSize;
+  /**
+   * Whether or not to render padding on the content section of the modal.
+   */
+  noContentPadding?: boolean = false;
+  /**
+   * Whether or not to show the close icon of the modal.
+   */
+  showCloseIcon?: boolean = true;
+}

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
@@ -69,7 +69,7 @@ describe('GoModalComponent', () => {
     });
 
     it('handles when no title and no modal size is set', () => {
-      component.currentComponent = new GoModalItem(GoTestModalHostComponent, {});
+      component.currentComponent = { component: GoTestModalHostComponent, bindings: { } };
 
       expect(component.modalTitle).toBeUndefined();
       expect(component.modalSize).toEqual(component.defaultModalSize);
@@ -81,7 +81,11 @@ describe('GoModalComponent', () => {
     });
 
     it('handles when a title is set', () => {
-      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { modalTitle: 'Test Title' });
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: { },
+        modalOptions: { modalTitle: 'Test Title' }
+      };
 
       expect(component.modalTitle).toBeUndefined();
 
@@ -91,7 +95,11 @@ describe('GoModalComponent', () => {
     });
 
     it('handles when a modal size is set to supported size', () => {
-      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { modalSize: 'xl' });
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: { },
+        modalOptions: { modalSize: 'xl' }
+      };
 
       expect(component.modalSize).toEqual(component.defaultModalSize);
 
@@ -100,18 +108,12 @@ describe('GoModalComponent', () => {
       expect(component.modalSize).toEqual('xl');
     });
 
-    it('handles when a modal size is set to unsupported size', () => {
-      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { modalSize: 'abc' });
-
-      expect(component.modalSize).toEqual(component.defaultModalSize);
-
-      component.loadComponent();
-
-      expect(component.modalSize).toEqual(component.defaultModalSize);
-    });
-
     it('sets closeWithBackdrop to false if not passed in', () => {
-      component.currentComponent = new GoModalItem(GoTestModalHostComponent, {  });
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: { }
+      };
+
       component.closeWithBackdrop = true;
 
       component.loadComponent();
@@ -120,7 +122,11 @@ describe('GoModalComponent', () => {
     });
 
     it('sets closeWithBackdrop to true if passed in', () => {
-      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { closeWithBackdrop: true });
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: { },
+        modalOptions: { closeWithBackdrop: true }
+      };
       component.closeWithBackdrop = false;
 
       component.loadComponent();
@@ -129,7 +135,11 @@ describe('GoModalComponent', () => {
     });
 
     it('sets showCloseIcon to true if not passed in', () => {
-      component.currentComponent = new GoModalItem(GoTestModalHostComponent, {  });
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: { }
+      };
+
       component.showCloseIcon = false;
 
       component.loadComponent();
@@ -138,7 +148,11 @@ describe('GoModalComponent', () => {
     });
 
     it('sets closeWithBackdrop to false if passed in', () => {
-      component.currentComponent = new GoModalItem(GoTestModalHostComponent, { showCloseIcon: false });
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: { },
+        modalOptions: { showCloseIcon: false }
+      };
       component.showCloseIcon = true;
 
       component.loadComponent();

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
@@ -5,7 +5,6 @@ import { Component, ViewChild } from '@angular/core';
 import { GoIconButtonModule } from '../go-icon-button/go-icon-button.module';
 import { GoModalComponent } from './go-modal.component';
 import { GoModalDirective } from './go-modal.directive';
-import { GoModalItem } from './go-modal.item';
 import { GoModalService } from './go-modal.service';
 
 describe('GoModalComponent', () => {
@@ -94,11 +93,47 @@ describe('GoModalComponent', () => {
       expect(component.modalTitle).toEqual('Test Title');
     });
 
+    /**
+     * @deprecated test
+     */
+    it('handles when a title is set (deprecated)', () => {
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: {
+          modalTitle: 'Test Title'
+        }
+      };
+
+      expect(component.modalTitle).toBeUndefined();
+
+      component.loadComponent();
+
+      expect(component.modalTitle).toEqual('Test Title');
+    });
+
     it('handles when a modal size is set to supported size', () => {
       component.currentComponent = {
         component: GoTestModalHostComponent,
         bindings: { },
         modalOptions: { modalSize: 'xl' }
+      };
+
+      expect(component.modalSize).toEqual(component.defaultModalSize);
+
+      component.loadComponent();
+
+      expect(component.modalSize).toEqual('xl');
+    });
+
+    /**
+     * @deprecated test
+     */
+    it('handles when a modal size is set to supported size (deprecated)', () => {
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: {
+          modalSize: 'xl'
+        }
       };
 
       expect(component.modalSize).toEqual(component.defaultModalSize);
@@ -134,6 +169,23 @@ describe('GoModalComponent', () => {
       expect(component.closeWithBackdrop).toEqual(true);
     });
 
+    /**
+     * @deprecated test
+     */
+    it('sets closeWithBackdrop to true if passed in (deprecated)', () => {
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: {
+          closeWithBackdrop: true
+        }
+      };
+      component.closeWithBackdrop = false;
+
+      component.loadComponent();
+
+      expect(component.closeWithBackdrop).toEqual(true);
+    });
+
     it('sets showCloseIcon to true if not passed in', () => {
       component.currentComponent = {
         component: GoTestModalHostComponent,
@@ -152,6 +204,23 @@ describe('GoModalComponent', () => {
         component: GoTestModalHostComponent,
         bindings: { },
         modalOptions: { showCloseIcon: false }
+      };
+      component.showCloseIcon = true;
+
+      component.loadComponent();
+
+      expect(component.showCloseIcon).toEqual(false);
+    });
+
+    /**
+     * @deprecated test
+     */
+    it('sets closeWithBackdrop to false if passed in (deprecated)', () => {
+      component.currentComponent = {
+        component: GoTestModalHostComponent,
+        bindings: {
+          showCloseIcon: false
+        }
       };
       component.showCloseIcon = true;
 

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
@@ -11,7 +11,9 @@ import {
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { GoModalOptions } from './go-modal-options';
 import { GoModalDirective } from './go-modal.directive';
+import { GoModalItem } from './go-modal.item';
 import { GoModalService } from './go-modal.service';
 
 @Component({
@@ -19,16 +21,10 @@ import { GoModalService } from './go-modal.service';
   templateUrl: './go-modal.component.html',
   styleUrls: ['./go-modal.component.scss']
 })
-export class GoModalComponent implements OnInit, OnDestroy {
-  readonly defaultModalSize: 'lg' | 'xl' = 'lg';
+export class GoModalComponent extends GoModalOptions implements OnInit, OnDestroy {
 
-  closeWithBackdrop: boolean = false;
-  currentComponent: any;
-  modalTitle: string;
-  modalSize: 'lg' | 'xl' = this.defaultModalSize;
-  noContentPadding: boolean = false;
+  currentComponent: GoModalItem<any>;
   opened: boolean = false;
-  showCloseIcon: boolean = true;
 
   private destroy$: Subject<void> = new Subject();
 
@@ -39,6 +35,7 @@ export class GoModalComponent implements OnInit, OnDestroy {
     private componentFactoryResolver: ComponentFactoryResolver,
     private goModalService: GoModalService
   ) {
+    super();
   }
 
   ngOnInit(): void {
@@ -74,28 +71,7 @@ export class GoModalComponent implements OnInit, OnDestroy {
       componentRef.instance[key] = this.currentComponent.bindings[key];
     });
 
-    // Set title for modal if provided
-    if (componentRef.instance['modalTitle']) {
-      this.modalTitle = componentRef.instance['modalTitle'];
-    } else {
-      this.modalTitle = '';
-    }
-
-    // Set modal size if provided (by default set to 'lg')`
-    if (componentRef.instance['modalSize'] === 'lg' || componentRef.instance['modalSize'] === 'xl') {
-      this.modalSize = componentRef.instance['modalSize'];
-    } else {
-      this.modalSize = this.defaultModalSize;
-    }
-
-    // Set close with backdrop if provided
-    this.closeWithBackdrop = componentRef.instance['closeWithBackdrop'] === true ? true : false;
-
-    // set content padding if provided
-    this.noContentPadding = componentRef.instance['noContentPadding'];
-
-    // set close icon if provided
-    this.showCloseIcon = componentRef.instance['showCloseIcon'] === false ? false : true;
+    this.setModalProperties(componentRef);
   }
 
   /**
@@ -115,6 +91,37 @@ export class GoModalComponent implements OnInit, OnDestroy {
 
   goModalClasses(): object {
     return { 'go-modal--visible': this.opened };
+  }
+
+  private setModalProperties(componentRef: ComponentRef<{}>): void {
+    if (this.currentComponent.modalOptions) {
+      Object.keys(this.currentComponent.modalOptions).forEach((key: string) => {
+        this[key] = this.currentComponent.modalOptions[key];
+      });
+    } else {
+      // Set title for modal if provided
+      if (componentRef.instance['modalTitle']) {
+        this.modalTitle = componentRef.instance['modalTitle'];
+      } else {
+        this.modalTitle = '';
+      }
+
+      // Set modal size if provided (by default set to 'lg')`
+      if (componentRef.instance['modalSize'] === 'lg' || componentRef.instance['modalSize'] === 'xl') {
+        this.modalSize = componentRef.instance['modalSize'];
+      } else {
+        this.modalSize = this.defaultModalSize;
+      }
+
+      // Set close with backdrop if provided
+      this.closeWithBackdrop = componentRef.instance['closeWithBackdrop'] === true ? true : false;
+
+      // set content padding if provided
+      this.noContentPadding = componentRef.instance['noContentPadding'];
+
+      // set close icon if provided
+      this.showCloseIcon = componentRef.instance['showCloseIcon'] === false ? false : true;
+    }
   }
 
   private destroyComponent(): void {

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.item.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.item.ts
@@ -1,5 +1,40 @@
 import { Type } from '@angular/core';
+import { GoModalOptions } from './go-modal-options';
 
-export class GoModalItem {
-  constructor(public component: Type<any>, public bindings: {}) {}
+export interface GoModalBindings {
+  /**
+   * @deprecated use modalOptions instead
+   */
+  closeWithBackdrop?: boolean;
+  /**
+   * @deprecated use modalOptions instead
+   */
+  modalTitle?: string;
+  /**
+   * @deprecated use modalOptions instead
+   */
+  modalSize?: 'lg' | 'xl';
+  /**
+   * @deprecated use modalOptions instead
+   */
+  noContentPadding?: boolean;
+  /**
+   * @deprecated use modalOptions instead
+   */
+  showCloseIcon?: boolean;
+}
+
+export interface GoModalItem<T> {
+  /**
+   * The Angular Component to be rendered in the Modal.
+   */
+  component: Type<T>;
+  /**
+   * The bindings for the Component being rendered.
+   */
+  bindings: GoModalBindings | Partial<T>;
+  /**
+   * Various configuration options for this instance of the Modal.
+   */
+  modalOptions?: GoModalOptions;
 }

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.service.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.service.spec.ts
@@ -26,16 +26,16 @@ describe('GoModalService', () => {
       spyOn(service, 'setComponent');
       spyOn(service, 'toggleModal');
 
-      service.openModal(GoTestModalComponent, { testingBinding: 'test'});
+      service.openModal(GoTestModalComponent, { testingBinding: 'test'}, { modalTitle: 'Test' });
 
-      expect(service.setComponent).toHaveBeenCalledWith(GoTestModalComponent, { testingBinding: 'test'});
+      expect(service.setComponent).toHaveBeenCalledWith(GoTestModalComponent, { testingBinding: 'test'}, { modalTitle: 'Test' });
       expect(service.toggleModal).toHaveBeenCalledWith(true);
     });
   });
 
   describe('setComponent', () => {
     it('emits the new component and its bindings from activeModalComponent', () => {
-      service.activeModalComponent.subscribe((item: GoModalItem) => {
+      service.activeModalComponent.subscribe((item: GoModalItem<GoTestModalComponent>) => {
         expect({...item}).toEqual({ component: GoTestModalComponent, bindings: { testingBinding: 'test'} });
       });
 

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.service.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.service.spec.ts
@@ -31,6 +31,19 @@ describe('GoModalService', () => {
       expect(service.setComponent).toHaveBeenCalledWith(GoTestModalComponent, { testingBinding: 'test'}, { modalTitle: 'Test' });
       expect(service.toggleModal).toHaveBeenCalledWith(true);
     });
+
+    /**
+     * @deprecated test
+     */
+    it('calls setComponent and toggleModal (deprecated)', () => {
+      spyOn(service, 'setComponent');
+      spyOn(service, 'toggleModal');
+
+      service.openModal(GoTestModalComponent, { testingBinding: 'test', modalTitle: 'Test' });
+
+      expect(service.setComponent).toHaveBeenCalledWith(GoTestModalComponent, { testingBinding: 'test', modalTitle: 'Test' }, undefined);
+      expect(service.toggleModal).toHaveBeenCalledWith(true);
+    });
   });
 
   describe('setComponent', () => {

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.service.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.service.ts
@@ -1,24 +1,35 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Type } from '@angular/core';
 
-import { GoModalItem } from './go-modal.item';
+import { GoModalBindings, GoModalItem } from './go-modal.item';
 import { Subject } from 'rxjs';
+import { GoModalOptions } from './go-modal-options';
 
 @Injectable()
 export class GoModalService {
-  activeModalComponent: Subject<GoModalItem> = new Subject<GoModalItem>();
+  activeModalComponent: Subject<GoModalItem<any>> = new Subject<GoModalItem<any>>();
   modalOpen: Subject<boolean> = new Subject<boolean>();
 
   constructor() {
     this.modalOpen.next(false);
   }
 
-  openModal(component: any, bindings: {}): void {
-    this.setComponent(component, bindings);
+  /**
+   * Opens an instance of the GoModal
+   * @param component Component to be rendered inside of Modal
+   * @param bindings Bindings for the Component being passed to the Modal. **Note: passing bindings for the Modal in this object is deprecated, use modalOptions instead.**
+   * @param modalOptions Various configurations for the Modal.
+   */
+  openModal<T>(component: Type<T>, bindings: Partial<T> | GoModalBindings, modalOptions?: GoModalOptions): void {
+    this.setComponent<T>(component, bindings, modalOptions);
     this.toggleModal(true);
   }
 
-  setComponent(component: any, bindings: {}): void {
-    this.activeModalComponent.next(new GoModalItem(component, bindings));
+  setComponent<T>(component: Type<T>, bindings: Partial<T> | GoModalBindings, modalOptions?: GoModalOptions): void {
+    if (modalOptions) {
+      this.activeModalComponent.next({ component, bindings, modalOptions });
+    } else {
+      this.activeModalComponent.next({ component, bindings });
+    }
   }
 
   toggleModal(open: boolean = true): void {

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas-options.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas-options.ts
@@ -1,0 +1,10 @@
+export class GoOffCanvasOptions {
+  /**
+   * The header text for the Off Canvas.
+   */
+  header?: string;
+  /**
+   * The width of the Off Canvas.
+   */
+  size?: 'large' | 'small' = 'small';
+}

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas-service.spec.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas-service.spec.ts
@@ -11,7 +11,7 @@ class GoTestOffCanvasComponent {}
 
 describe('GoOffCanvasService', () => {
   let service: GoOffCanvasService;
-  const offCanvasItemMock: GoOffCanvasItem = {
+  const offCanvasItemMock: GoOffCanvasItem<GoTestOffCanvasComponent> = {
     component: GoTestOffCanvasComponent,
     bindings: { testingBinding: 'test'}
   };
@@ -31,7 +31,7 @@ describe('GoOffCanvasService', () => {
 
   describe('openOffCanvas', () => {
     it('emits the new component and its bindings from activeOffCanvasComponent', () => {
-      service.activeOffCanvasComponent.subscribe((item: GoOffCanvasItem) => {
+      service.activeOffCanvasComponent.subscribe((item: GoOffCanvasItem<GoTestOffCanvasComponent>) => {
         expect({...item}).toEqual(offCanvasItemMock);
       });
 

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.interface.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.interface.ts
@@ -1,8 +1,25 @@
 import { Type } from '@angular/core';
+import { GoOffCanvasOptions } from './go-off-canvas-options';
 
-export interface GoOffCanvasItem {
-  component: Type<{}>;
-  bindings: {};
+export interface GoOffCanvasItem<T> {
+  /**
+   * The Angular Component to be rendered in the Off Canvas.
+   */
+  component: Type<T>;
+  /**
+   * The bindings for the Component being rendered.
+   */
+  bindings: Partial<T>;
+  /**
+   * @deprecated use offCanvasOptions instead
+   */
   header?: string;
+  /**
+   * @deprecated use offCanvasOptions instead
+   */
   size?: 'large' | 'small';
+  /**
+   * Various configuration options for this instance of the Off Canvas.
+   */
+  offCanvasOptions?: GoOffCanvasOptions;
 }

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.service.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.service.ts
@@ -6,14 +6,18 @@ import { GoOffCanvasItem } from './go-off-canvas.interface';
   providedIn: 'root'
 })
 export class GoOffCanvasService {
-  activeOffCanvasComponent: Subject<GoOffCanvasItem> = new Subject<GoOffCanvasItem>();
+  activeOffCanvasComponent: Subject<GoOffCanvasItem<any>> = new Subject<GoOffCanvasItem<any>>();
   offCanvasOpen: Subject<boolean> = new Subject<boolean>();
 
   constructor() {
     this.setOffCanvasStatus(false);
   }
 
-  public openOffCanvas(offCanvasItem: GoOffCanvasItem): void {
+  /**
+   * Opens an instance of the GoOffCanvas
+   * @param offCanvasItem Configuration for the Off Canvas.
+   */
+  public openOffCanvas<T>(offCanvasItem: GoOffCanvasItem<T>): void {
     this.activeOffCanvasComponent.next(offCanvasItem);
     this.setOffCanvasStatus(true);
   }

--- a/projects/go-lib/src/public_api.ts
+++ b/projects/go-lib/src/public_api.ts
@@ -92,12 +92,14 @@ export * from './lib/components/go-loader/go-loader.module';
 export * from './lib/components/go-modal/go-modal.component';
 export * from './lib/components/go-modal/go-modal.module';
 export * from './lib/components/go-modal/go-modal.service';
+export * from './lib/components/go-modal/go-modal-options';
 
 // Off Canvas
 export * from './lib/components/go-off-canvas/go-off-canvas.component';
 export * from './lib/components/go-off-canvas/go-off-canvas.module';
 export * from './lib/components/go-off-canvas/go-off-canvas.service';
 export * from './lib/components/go-off-canvas/go-off-canvas.interface';
+export * from './lib/components/go-off-canvas/go-off-canvas-options';
 
 // Pill
 export * from './lib/components/go-pill/go-pill.component';

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.html
@@ -1,8 +1,8 @@
 <header class="go-page-title">
   <h1 class="go-heading-1">{{ pageTitle }}</h1>
   <a
-  [href]="linkToSource"
-  target="_blank">
+    [href]="linkToSource"
+    target="_blank">
     <go-button buttonVariant="neutral"> View on GitHub </go-button>
   </a>
 </header>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/modal-docs/modal-docs.component.ts
@@ -13,8 +13,11 @@ export class ModalDocsComponent {
   pageTitle: string = 'Modal';
 
   componentBindings: string = `
-  @Input() modalTitle: string = '';
-  @Input() modalSize: 'lg' | 'xl' = 'lg';
+  closeWithBackdrop?: boolean = false;
+  modalTitle: string = '';
+  modalSize: 'lg' | 'xl' = 'lg';
+  noContentPadding?: boolean = false;
+  showCloseIcon?: boolean = true;
   `;
 
   appModuleImport: string = `
@@ -66,40 +69,56 @@ export class ModalDocsComponent {
 
   ex_ModalDocsOpenModal: string = `
   openModal() {
-    this.goModalService.openModal(ModalTestComponent, { modalTitle: 'Example Title', modalSize: 'xl', content: 'This is a modal!' });
+    this.goModalService.openModal(ModalTestComponent, {
+      content: 'This is a modal!'
+    }, {
+      modalTitle: 'Example Title'
+    };
   }
   `;
 
   ex_ModalDocsHtml: string = `<go-button (handleClick)="openModal()">Click Me</go-button>`;
 
   ex_ModalDocsOpenLgModal: string = `
-  this.goModalService.openModal(ModalTestComponent, { modalTitle: 'LG Modal (Default)', content: 'This is a lg modal' });
+  this.goModalService.openModal(ModalTestComponent, {
+    content: 'This is a lg modal'
+  }, {
+    modalTitle: 'LG Modal (Default)'
+  });
   `;
 
   ex_ModalDocsOpenXlModal: string = `
-  this.goModalService.openModal(ModalTestComponent, { modalTitle: 'XL Modal', modalSize: 'xl', content: 'This is a xl modal' });
+  this.goModalService.openModal(ModalTestComponent, {
+    content: 'This is a xl modal'
+  }, {
+    modalTitle: 'XL Modal',
+    modalSize: 'xl'
+  });
   `;
 
   ex_ModalDocsNoPadding: string = `
   this.goModalService.openModal(ModalTestComponent, {
+    content: 'This area has no padding'
+  }, {
     modalTitle: 'No Padding Example',
-    content: 'This area has no padding',
     noContentPadding: true
   });
   `;
 
   ex_ModalDocsCloseWithBackdrop: string = `
   this.goModalService.openModal(ModalTestComponent, {
+    content: 'You can close this modal by clicking on the page outside of the modal'
+  }, {
     modalTitle: 'Close With Backdrop Example',
-    content: 'You can close this modal by clicking on the page outside of the modal',
     closeWithBackdrop: true
   });
   `;
 
   ex_ModalDocsNoCloseIcon: string = `
   this.goModalService.openModal(ModalTestComponent, {
+    content: 'The only way to close this modal is by clicking outside of the modal on the backdrop'
+  }, {
     modalTitle: 'Close With Backdrop Example',
-    content: 'The only way to close this modal is by clicking outside of the modal on the backdrop',
     closeWithBackdrop: true,
     showCloseIcon: false
   });
@@ -110,37 +129,53 @@ export class ModalDocsComponent {
   constructor(private goModalService: GoModalService) { }
 
   openModal(): void {
-    this.goModalService.openModal(ModalTestComponent, { modalTitle: 'Example Title', modalSize: 'xl', content: 'This is a modal!' });
+    this.goModalService.openModal(ModalTestComponent, {
+      content: 'This is a modal!'
+    }, {
+      modalTitle: 'Example Title'
+    });
   }
 
   openLgModal(): void {
-    this.goModalService.openModal(ModalTestComponent, { modalTitle: 'LG Modal (Default)', content: 'This is a lg modal' });
+    this.goModalService.openModal(ModalTestComponent, {
+      content: 'This is a lg modal'
+    }, {
+      modalTitle: 'LG Modal (Default)'
+    });
   }
 
   openXlModal(): void {
-    this.goModalService.openModal(ModalTestComponent, { modalTitle: 'XL Modal', modalSize: 'xl', content: 'This is a xl modal' });
+    this.goModalService.openModal(ModalTestComponent, {
+      content: 'This is a xl modal'
+    }, {
+      modalTitle: 'XL Modal',
+      modalSize: 'xl'
+    });
   }
 
   openNoPaddingModal(): void {
     this.goModalService.openModal(ModalTestComponent, {
+      content: 'This area has no padding'
+    }, {
       modalTitle: 'No Padding Example',
-      content: 'This area has no padding',
       noContentPadding: true
     });
   }
 
   openCloseWithBackdropModal(): void {
     this.goModalService.openModal(ModalTestComponent, {
+      content: 'You can close this modal by clicking on the page outside of the modal'
+    }, {
       modalTitle: 'Close With Backdrop Example',
-      content: 'You can close this modal by clicking on the page outside of the modal',
       closeWithBackdrop: true
     });
   }
 
   openNoCloseIconModal(): void {
     this.goModalService.openModal(ModalTestComponent, {
+      content: 'The only way to close this modal is by clicking outside of the modal on the backdrop'
+    }, {
       modalTitle: 'Close With Backdrop Example',
-      content: 'The only way to close this modal is by clicking outside of the modal on the backdrop',
       closeWithBackdrop: true,
       showCloseIcon: false
     });

--- a/projects/go-style-guide/src/app/features/ui-kit/components/off-canvas-docs/off-canvas-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/off-canvas-docs/off-canvas-docs.component.html
@@ -89,7 +89,9 @@
               To open the off canvas, use the service to call
               <code class="code-block--inline">openOffCanvas</code>.
               This method takes the component type (BasicTestComponent in our case),
-              the bindings for that component as an object, and an optional header binding as a string.
+              the bindings for that component as an object,
+              and an optional <code class="code-block--inline">offCanvasOptions</code> object with
+              the header property as a string.
             </p>
             <code [highlight]="functionExample"></code>
           </li>
@@ -132,8 +134,9 @@
     <div class="go-container" go-card-content>
       <div class="go-column go-column--100 go-column--no-padding">
         <p class="go-body-copy">
-          To render a large off canvas, add the <code class="code-block--inline">size</code> option to the <code
-          class="code-block--inline">openOffCanvas</code> method.
+          To render a large off canvas, add the <code class="code-block--inline">size</code> option to the 
+          <code class="code-block--inline">offCanvasOptions</code> property when calling the
+          <code class="code-block--inline">openOffCanvas</code> method.
         </p>
       </div>
       <div class="go-column go-column--50">

--- a/projects/go-style-guide/src/app/features/ui-kit/components/off-canvas-docs/off-canvas-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/off-canvas-docs/off-canvas-docs.component.ts
@@ -58,9 +58,11 @@ export class OffCanvasDocsComponent {
     this.goOffCanvasService.openOffCanvas({
       component: BasicTestComponent,
       bindings: {
-        someBinding: 'monkey'
+        fakeTitle: 'Basic Off Canvas Component'
       },
-      header: 'Test Header'
+      offCanvasOptions: {
+        header: 'Test Header'
+      }
     });
   }
   `;
@@ -77,12 +79,14 @@ export class OffCanvasDocsComponent {
   largeOffCanvasExample: string = `
   openOffCanvas(): void {
     this.goOffCanvasService.openOffCanvas({
-      component: BasicTestComponent,
+      component: BasicTestLargeComponent,
       bindings: {
-        someBinding: 'monkey'
+        fakeTitle: 'Basic Off Canvas Component'
       },
-      header: 'Test Header',
-      size: 'large'
+      offCanvasOptions: {
+        header: 'Test Header',
+        size: 'large'
+      }
     });
   }
   `;
@@ -132,9 +136,11 @@ export class OffCanvasDocsComponent {
     this.goOffCanvasService.openOffCanvas({
       component: BasicTestComponent,
       bindings: {
-        someBinding: 'Basic Off Canvas Component'
+        fakeTitle: 'Basic Off Canvas Component'
       },
-      header: 'Test Header'
+      offCanvasOptions: {
+        header: 'Test Header'
+      }
     });
   }
 
@@ -142,10 +148,12 @@ export class OffCanvasDocsComponent {
     this.goOffCanvasService.openOffCanvas({
       component: BasicTestLargeComponent,
       bindings: {
-        someBinding: 'Basic Off Canvas Component'
+        fakeTitle: 'Basic Off Canvas Component',
       },
-      header: 'Test Header',
-      size: 'large'
+      offCanvasOptions: {
+        header: 'Test Header',
+        size: 'large'
+      }
     });
   }
 
@@ -153,9 +161,11 @@ export class OffCanvasDocsComponent {
     this.goOffCanvasService.openOffCanvas({
       component: BasicTestSubmitButtonComponent,
       bindings: {
-        someBinding: 'Basic Off Canvas Component'
+        fakeTitle: 'Basic Off Canvas Component'
       },
-      header: 'Test Header',
+      offCanvasOptions: {
+        header: 'Test Header'
+      }
     });
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
This PR addresses the potential for mismatched typing for both the off-canvas and modal implementations.

#### Modal
Currently the `openModal` method allows for `any` type to be passed in for the `component` and `bindings` properties. Additionally, the bindings for the modal itself were passed in through the `bindings` object which was originally intended to be for the bindings on the component being rendered by the modal.

#### Off Canvas
Currently the `openOffCanvas` method allows for `any` type to be passed in for the `component` and `bindings` properties. Additionally the bindings for the off canvas are set through properties on the object passed into this method.

## What is the new behavior?

#### Modal
There is now partial type enforcement on the `bindings` param. It will only allow for properties that exist on the Component passed into the `component` param or the properties available on the modal itself (although this is deprecated and should not be used in new code).

All modal implementations that require properties on the modal itself to be set should now use the `modalOptions` optional param available on the `openModal` method.

#### Off Canvas
There is now partial type enforcement on the `bindings` property. It will only allow for properties that exist on the Component passed into the `component` property.

The existing properties for `header` and `size` remain functional, but are now deprecated and should not be used.

All off canvas implementations that require properties on the off canvas itself to be set should now use the `offCanvasOptions` optional property.

#### In both cases, you can no longer specify properties on the `bindings` property that do not exist on the Component that is set to the `component` property (or in the case of the modal, properties that exist on the GoModal).

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

This PR was engineered in a way such that it will not introduce breaking changes into your app (unless the modal or off-canvas implementations were done incorrectly). We did include deprecation warnings where applicable to help with education on the new approach as well as indicating what not to use.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
