### PR TITLE
[Bug] Table SelectAll Subscription

### DIFF
--- a/projects/go-lib/karma.conf.js
+++ b/projects/go-lib/karma.conf.js
@@ -16,9 +16,9 @@ module.exports = function (config) {
     reporters: ['dots'],
     port: 9876,
     colors: true,
-    logLevel: config.LOG_INFO,
+    logLevel: config.LOG_WARN,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
     singleRun: false
   });
 };

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -391,7 +391,7 @@ describe('GoTableComponent', () => {
 
       component.selectAllControl.setValue(false);
 
-      component['selectionSubscriptions'].unsubscribe();
+      component.ngOnDestroy();
 
       expect(component.selectAllIndeterminate).toBe(false);
     });
@@ -410,7 +410,7 @@ describe('GoTableComponent', () => {
 
       component.selectAllControl.setValue(true);
 
-      component['selectionSubscriptions'].unsubscribe();
+      component.ngOnDestroy();
 
       expect(component.targetedRows).toEqual([]);
     });
@@ -420,7 +420,7 @@ describe('GoTableComponent', () => {
 
       component.selectAllControl.setValue(false);
 
-      component['selectionSubscriptions'].unsubscribe();
+      component.ngOnDestroy();
 
       expect(component.targetedRows).toEqual([]);
     });
@@ -437,7 +437,7 @@ describe('GoTableComponent', () => {
 
       component.selectAllControl.setValue(false);
 
-      component['selectionSubscriptions'].unsubscribe();
+      component.ngOnDestroy();
 
       expect(component.selectAllEvent.emit).toHaveBeenCalledWith(selectionEventData);
     });
@@ -956,7 +956,7 @@ describe('GoTableComponent', () => {
 
       component.selectAllControl.setValue(true);
 
-      component['selectionSubscriptions'].unsubscribe();
+      component.ngOnDestroy();
 
       expect(component.rowSelectForm.value['selection_1']).toBe(true);
     });

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.spec.ts
@@ -149,18 +149,6 @@ describe('GoTableComponent', () => {
     });
   });
 
-  describe('afterViewInit', () => {
-    afterEach(() => {
-      component.selectAllControl.setValue(false);
-    });
-
-    it('should select all rows if preselected', () => {
-      component.tableConfig.preselected = true;
-      component.ngAfterViewInit();
-      expect(component.selectAllControl.value).toBe(true);
-    });
-  });
-
   describe('setPageByPageNumber', () => {
     beforeEach(() => {
       component.localTableConfig.totalCount = 135;
@@ -399,7 +387,11 @@ describe('GoTableComponent', () => {
     });
 
     it('should set selectAllIndeterminate to false if selectAll toggled off', () => {
+      component.ngOnInit();
+
       component.selectAllControl.setValue(false);
+
+      component['selectionSubscriptions'].unsubscribe();
 
       expect(component.selectAllIndeterminate).toBe(false);
     });
@@ -414,13 +406,21 @@ describe('GoTableComponent', () => {
     });
 
     it('should reset targetedRows if toggling selectAll on', () => {
+      component.ngOnInit();
+
       component.selectAllControl.setValue(true);
+
+      component['selectionSubscriptions'].unsubscribe();
 
       expect(component.targetedRows).toEqual([]);
     });
 
     it('should reset targetedRows if toggling selectAll off', () => {
+      component.ngOnInit();
+
       component.selectAllControl.setValue(false);
+
+      component['selectionSubscriptions'].unsubscribe();
 
       expect(component.targetedRows).toEqual([]);
     });
@@ -433,7 +433,11 @@ describe('GoTableComponent', () => {
       };
       spyOn(component.selectAllEvent, 'emit');
 
+      component.ngOnInit();
+
       component.selectAllControl.setValue(false);
+
+      component['selectionSubscriptions'].unsubscribe();
 
       expect(component.selectAllEvent.emit).toHaveBeenCalledWith(selectionEventData);
     });
@@ -946,10 +950,13 @@ describe('GoTableComponent', () => {
       component.tableConfig.selectBy = 'id';
 
       component.renderTable();
+      component.ngOnInit();
 
       expect(component.rowSelectForm.value['selection_1']).toBe(false);
 
       component.selectAllControl.setValue(true);
+
+      component['selectionSubscriptions'].unsubscribe();
 
       expect(component.rowSelectForm.value['selection_1']).toBe(true);
     });
@@ -1098,6 +1105,16 @@ describe('GoTableComponent', () => {
       component.tableConfig = tableConfig;
       component.tableConfig.dataMode = GoTableDataSource.client;
       component.tableConfig.tableData = fakeTableData;
+    });
+
+    afterEach(() => {
+      component.selectAllControl.setValue(false);
+    });
+
+    it('should select all rows if preselected', () => {
+      component.tableConfig.preselected = true;
+      component.ngAfterViewInit();
+      expect(component.selectAllControl.value).toBe(true);
     });
 
     it('performs a search if datamode is client and table is searchable', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Whenever the `tableConfig` of the `go-table` is assigned (or reassigned) the table subscribes to the `selectAllControl`. This results in multiple subscriptions on the single control. We watch for changes to this control and emit an event whenever it changes. This is problematic because we will emit the event for each subscription. 

This is especially problematic when pagination or sorting happens.

## What is the new behavior?
This moves the subscription into the `ngOnInit` so that we only subscribe to the changes once per lifetime of the table.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
