### PR TITLE
[Bug] OffCanvas & Modal reset defaults on close

### DIFF
--- a/projects/go-lib/src/lib/components/go-modal/go-modal-options.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal-options.ts
@@ -8,7 +8,7 @@ export class GoModalOptions {
   /**
    * The title for the modal.
    */
-  modalTitle?: string;
+  modalTitle?: string = '';
   /**
    * The general size for the modal.
    */

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.spec.ts
@@ -58,6 +58,36 @@ describe('GoModalComponent', () => {
 
       expect(component.goModalHost.viewContainerRef.clear).toHaveBeenCalled();
     });
+
+    it('resets default options when off canvas is closed', () => {
+      spyOn(goModalService, 'toggleModal').and.callThrough();
+
+      goModalService.openModal(
+        GoTestModalHostComponent,
+        {},
+        {
+          closeWithBackdrop: true,
+          modalTitle: 'Hogwarts',
+          modalSize: 'xl',
+          noContentPadding: true,
+          showCloseIcon: false
+        }
+      );
+
+      expect(component.closeWithBackdrop).toEqual(true);
+      expect(component.modalTitle).toEqual('Hogwarts');
+      expect(component.modalSize).toEqual('xl');
+      expect(component.noContentPadding).toEqual(true);
+      expect(component.showCloseIcon).toEqual(false);
+
+      goModalService.toggleModal(false);
+
+      expect(component.closeWithBackdrop).toBe(false);
+      expect(component.modalTitle).toEqual('');
+      expect(component.modalSize).toEqual('lg');
+      expect(component.noContentPadding).toEqual(false);
+      expect(component.showCloseIcon).toEqual(true);
+    });
   });
 
   describe('loadComponent', () => {

--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
@@ -41,7 +41,7 @@ export class GoModalComponent extends GoModalOptions implements OnInit, OnDestro
   ngOnInit(): void {
     this.goModalService.activeModalComponent
       .pipe(takeUntil(this.destroy$))
-      .subscribe((value: any) => {
+      .subscribe((value: GoModalItem<any>) => {
         this.currentComponent = value;
         this.loadComponent();
       });
@@ -52,6 +52,7 @@ export class GoModalComponent extends GoModalOptions implements OnInit, OnDestro
         this.opened = value;
         if (this.opened === false) {
           this.destroyComponent();
+          this.resetDefaults();
         }
       });
   }
@@ -91,6 +92,13 @@ export class GoModalComponent extends GoModalOptions implements OnInit, OnDestro
 
   goModalClasses(): object {
     return { 'go-modal--visible': this.opened };
+  }
+
+  private resetDefaults(): void {
+    const options: GoModalOptions = new GoModalOptions();
+    Object.keys(options).forEach((key: string) => {
+      this[key] = options[key];
+    });
   }
 
   private setModalProperties(componentRef: ComponentRef<{}>): void {

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas-options.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas-options.ts
@@ -2,7 +2,7 @@ export class GoOffCanvasOptions {
   /**
    * The header text for the Off Canvas.
    */
-  header?: string;
+  header?: string = '';
   /**
    * The width of the Off Canvas.
    */

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.component.spec.ts
@@ -40,12 +40,12 @@ describe('GoOffCanvasComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GoOffCanvasComponent);
     goOffCanvasHostFixture = TestBed.createComponent(GoTestOffCanvasHostComponent);
+    offCanvasService = TestBed.get(GoOffCanvasService);
 
     component = fixture.componentInstance;
     component.goOffCanvasHost = goOffCanvasHostFixture.componentInstance.goOffCanvasHost;
 
     fixture.detectChanges();
-    offCanvasService = TestBed.get(GoOffCanvasService);
   });
 
   it('should create', () => {
@@ -89,6 +89,27 @@ describe('GoOffCanvasComponent', () => {
 
       offCanvasService.closeOffCanvas();
       expect(component.goOffCanvasHost.viewContainerRef.clear).toHaveBeenCalled();
+    });
+
+    it('resets default options when off canvas is closed', () => {
+      spyOn(offCanvasService, 'closeOffCanvas').and.callThrough();
+
+      offCanvasService.openOffCanvas({
+        component: GoTestOffCanvasHostComponent,
+        bindings: {},
+        offCanvasOptions: {
+          header: 'Old Header',
+          size: 'large'
+        }
+      });
+
+      expect(component.header).toEqual('Old Header');
+      expect(component.size).toEqual('large');
+
+      offCanvasService.closeOffCanvas();
+
+      expect(component.header).toBe('');
+      expect(component.size).toBe('small');
     });
   });
 

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.component.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.component.ts
@@ -66,6 +66,7 @@ export class GoOffCanvasComponent extends GoOffCanvasOptions implements OnInit, 
         this.opened = value;
         if (this.opened === false) {
           this.destroyComponent();
+          this.resetDefaults();
         }
       });
   }
@@ -99,6 +100,13 @@ export class GoOffCanvasComponent extends GoOffCanvasOptions implements OnInit, 
     });
 
     this.setOffCanvasProperties();
+  }
+
+  private resetDefaults(): void {
+    const options: GoOffCanvasOptions = new GoOffCanvasOptions();
+    Object.keys(options).forEach((key: string) => {
+      this[key] = options[key];
+    });
   }
 
   private setOffCanvasProperties(): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
~~Docs have been added or updated~~

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Resolves #744 

## What is the new behavior?
When the modal or off-canvas is closed their configurations are reset to their respective defaults.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
