### PR TITLE
[Bug] SCSS variable causing broken build

### DIFF
--- a/projects/go-lib/src/styles/_variables.scss
+++ b/projects/go-lib/src/styles/_variables.scss
@@ -13,7 +13,7 @@ $global-box-shadow--regular: 0 0 2px 0 rgba(0, 0, 0, .12), 0 3px 6px 0 rgba(0, 0
 $global-box-shadow--search: 0 1px 6px 0 rgba(32, 33, 36, .28);
 $global-box-shadow--large: 0 7px 14px 0 rgba(65, 54, 94, .10), 0 3px 6px 0 rgba(0, 0, 0, .07);
 $global-box-shadow--small: 0 1px 2px 0 rgba(0, 0, 0, .20);
-$global-box-shadow--dark-popup: 0 2px 7px 2px rgb(0 0 0 / 22%), 0 2px 4px 0 rgb(0 0 0 / 20%);
+$global-box-shadow--dark-popup: 0 2px 7px 2px rgba(0, 0, 0, .22), 0 2px 4px 0 rgba(0, 0, 0, .2);
 // scss-lint:enable ColorVariable
 
 // Structural


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
~~Tests for the changes have been added~~
~~Docs have been added or updated~~

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
After installing v1.9.0 in an external repo, the SCSS variable in question is not formatted correctly for a production build to process it. This would not have been caught in any of our checks we have set up currently because we do not test compiling the lib project into a package, install it in a separate project, and try to compile it.

## What is the new behavior?
Fixes the variable to be formatted correctly.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
