### PR TITLE
Add 'Dismissable' argument to Toaster Service

### DIFF
--- a/projects/go-lib/src/lib/components/go-toaster/go-toaster.model.ts
+++ b/projects/go-lib/src/lib/components/go-toaster/go-toaster.model.ts
@@ -2,4 +2,5 @@ export interface ToastInterface {
   header?: string;
   message?: string;
   type?: string;
+  dismissable?: boolean;
 }

--- a/projects/go-lib/src/lib/components/go-toaster/go-toaster.service.ts
+++ b/projects/go-lib/src/lib/components/go-toaster/go-toaster.service.ts
@@ -75,6 +75,7 @@ export class GoToasterService {
     comp.message = toastInterface.message;
     comp.type = toastInterface.type;
     comp.header = toastInterface.header;
+    comp.dismissable = toastInterface.dismissable;
     comp.duration = duration;
 
     return  comp;

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
@@ -88,6 +88,9 @@ export class ToastDocsComponent {
 
   // you can adjust the duration of the toast by passing in the duration param:
   this.toasterService.toastSuccess({ message: 'You clicked the button!' }, 7000);
+
+  // you can also make the toast dismissable by setting the "dismissable" property on the ToastInterface param:
+  this.toasterService.toastSuccess({ message: 'You clicked the button!', dimissable: true });
   `;
 
   toaster_app_ts: string = `


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Currently, toasts that come in from the `goToasterService` aren't dimissable. The `GoToastComponent` supports a `dismissable` input, so we should add this to the service too.

## What is the new behavior?

The `goToasterService` supports an additional argument, `dismissable` through the `toastInterface`.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No