### PR TITLE
[Bug] Go-Select Multi-Select errors when "items" null

### DIFF
--- a/projects/go-lib/src/lib/components/go-select/go-select.component.html
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.html
@@ -30,7 +30,7 @@
   [virtualScroll]="virtualScroll"
   (scrollToEnd)="onScrollToEnd()"
   (scroll)="onScroll($event)">
-  <ng-container *ngIf="multiple && showSelectAll && items?.length > 0">
+  <ng-container *ngIf="multiple && showSelectAll && items?.length">
     <ng-template ng-header-tmp>
       <button
         (click)="onSelectAll()"

--- a/projects/go-lib/src/lib/components/go-select/go-select.component.html
+++ b/projects/go-lib/src/lib/components/go-select/go-select.component.html
@@ -30,7 +30,7 @@
   [virtualScroll]="virtualScroll"
   (scrollToEnd)="onScrollToEnd()"
   (scroll)="onScroll($event)">
-  <ng-container *ngIf="multiple && showSelectAll && items.length > 0">
+  <ng-container *ngIf="multiple && showSelectAll && items?.length > 0">
     <ng-template ng-header-tmp>
       <button
         (click)="onSelectAll()"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
~~Tests for the changes have been added~~
~~Docs have been added or updated~~

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
In the `go-select`, when `multiple` is `true` and `items` are `null` it is throwing a console error saying `cannot read property "length" of undefined".

## What is the new behavior?
It no longer does that

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
