### PR TITLE
[Feature] go-toast maxHeight & icon overrides

### DIFF
--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -8,40 +8,44 @@
     </go-icon>
   </div>
   <div
-    class="go-toast-content"
-    [ngClass]="{ 'go-toast-content--no-title': !header }">
-    <h4
-      class="go-heading-4 go-toast-content__title"
-      *ngIf="header || headerContent">
-      <ng-container *ngIf="headerContent; else headerContentElse">
-        <ng-container *ngTemplateOutlet="headerContent"></ng-container>
+    class="go-toast__container"
+    [ngClass]="{ 'go-toast__container--max-height': enableMaxHeight }">
+    <div
+      class="go-toast-content"
+      [ngClass]="{ 'go-toast-content--no-title': !header }">
+      <h4
+        class="go-heading-4 go-toast-content__title"
+        *ngIf="header || headerContent">
+        <ng-container *ngIf="headerContent; else headerContentElse">
+          <ng-container *ngTemplateOutlet="headerContent"></ng-container>
+        </ng-container>
+        <ng-template #headerContentElse>
+          {{ header }}
+        </ng-template>
+      </h4>
+  
+      <ng-container *ngIf="messageContent; else messageContentElse">
+        <p class="go-toast-content__message">
+         <ng-container *ngTemplateOutlet="messageContent"></ng-container>
+        </p>
       </ng-container>
-      <ng-template #headerContentElse>
-        {{ header }}
+      <ng-template #messageContentElse>
+        <p
+          class="go-toast-content__message"
+          [innerHTML]="message">
+        </p>
       </ng-template>
-    </h4>
-
-    <ng-container *ngIf="messageContent; else messageContentElse">
-      <p class="go-toast-content__message">
-       <ng-container *ngTemplateOutlet="messageContent"></ng-container>
-      </p>
-    </ng-container>
-    <ng-template #messageContentElse>
-      <p
-        class="go-toast-content__message"
-        [innerHTML]="message">
-      </p>
-    </ng-template>
-  </div>
-  <div
-    class="go-toast-dismiss"
-    *ngIf="dismissable">
-    <go-icon-button
-      buttonIcon="close"
-      (handleClick)="dismiss()">
-    </go-icon-button>
-  </div>
-  <div class="go-toast__actions" *ngIf="showToastActions">
-    <ng-content select="[go-toast-action]"></ng-content>
+    </div>
+    <div
+      class="go-toast-dismiss"
+      *ngIf="dismissable">
+      <go-icon-button
+        buttonIcon="close"
+        (handleClick)="dismiss()">
+      </go-icon-button>
+    </div>
+    <div class="go-toast__actions" *ngIf="showToastActions">
+      <ng-content select="[go-toast-action]"></ng-content>
+    </div>
   </div>
 </div>

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -1,10 +1,10 @@
 <div class="go-toast" [ngClass]="{'go-toast--dark': theme === 'dark'}">
-  <div class="go-toast-strip" [ngClass]="statusClass"></div>
+  <div class="go-toast-strip" [ngClass]="_status"></div>
   <div class="go-toast-status">
     <go-icon
       class="go-toast-status__icon"
-      [ngClass]="statusClass"
-      [icon]="icon">
+      [ngClass]="_status"
+      [icon]="_icon">
     </go-icon>
   </div>
   <div

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.scss
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.scss
@@ -1,6 +1,8 @@
 @import '../../../../styles/variables';
 @import '../../../../styles/mixins';
 
+$toast-padding: 1.25rem;
+
 .go-toast {
   background: $theme-light-bg;
   border-radius: $global-radius;
@@ -14,7 +16,7 @@
     display: flex;
     flex: 1;
     justify-content: flex-end;
-    padding: 1.25rem;
+    padding: $toast-padding;
   }
 
   &__container {
@@ -81,7 +83,7 @@
   flex: 1;
   flex-direction: column;
   justify-content: center;
-  padding: 1.25rem 1.25rem 1.25rem 0;
+  padding: $toast-padding $toast-padding $toast-padding 0;
 
   &__title {
     margin-bottom: .25rem;

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.scss
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.scss
@@ -10,10 +10,22 @@
 
   &__actions {
     align-items: center;
+    align-self: flex-start;
     display: flex;
     flex: 1;
     justify-content: flex-end;
-    padding: .875rem 1.25rem;
+    padding: 1.25rem;
+  }
+
+  &__container {
+    align-items: baseline;
+    display: flex;
+    flex: 1 1 auto;
+
+    &--max-height {
+      max-height: 9rem;
+      overflow-y: auto;
+    }
   }
 
   &--dark {
@@ -69,7 +81,7 @@
   flex: 1;
   flex-direction: column;
   justify-content: center;
-  padding: 1rem 1.25rem 1rem 0;
+  padding: 1.25rem 1.25rem 1.25rem 0;
 
   &__title {
     margin-bottom: .25rem;

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.spec.ts
@@ -28,31 +28,40 @@ describe('GoToastComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('ngOnInit', () => {
-    it('sets a default statusClass if no type is passed in', () => {
+  describe('_status', () => {
+    it('returns a default status if no type is passed in', () => {
       fixture.detectChanges();
 
-      expect(component.statusClass).toEqual('go-toast-status--neutral');
+      expect(component._status).toEqual('go-toast-status--neutral');
     });
 
-    it('sets a statusClass if type is passed in', () => {
+    it('returns a type status if type is passed in', () => {
       component.type = 'positive';
       fixture.detectChanges();
 
-      expect(component.statusClass).toEqual('go-toast-status--positive');
+      expect(component._status).toEqual('go-toast-status--positive');
     });
+  });
 
-    it('sets a default icon if no type is passed in', () => {
+  describe('_icon', () => {
+    it('returns a default icon if no type is passed in', () => {
       fixture.detectChanges();
 
-      expect(component.icon).toEqual('notifications_none');
+      expect(component._icon).toEqual('notifications_none');
     });
 
-    it('should set an icon if type is passed in', () => {
+    it('returns an icon if type is passed in', () => {
       component.type = 'positive';
       fixture.detectChanges();
 
-      expect(component.icon).toEqual('done');
+      expect(component._icon).toEqual('done');
+    });
+
+    it('returns an icon if icon is passed in', () => {
+      component.icon = 'pets';
+      fixture.detectChanges();
+
+      expect(component._icon).toEqual('pets');
     });
   });
 

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
@@ -19,11 +19,12 @@ export class GoToastComponent implements OnInit {
   duration: number;
 
   @Input() dismissable: boolean = false;
+  @Input() enableMaxHeight: boolean = true;
   @Input() header: string;
   @Input() message: string;
-  @Input() type: string;
   @Input() showToastActions: boolean = false;
   @Input() theme: 'light' | 'dark' = 'light';
+  @Input() type: string;
 
   @Output() handleDismiss: EventEmitter<void> = new EventEmitter();
 

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
@@ -3,7 +3,6 @@ import {
   ContentChild,
   EventEmitter,
   Input,
-  OnInit,
   Output,
   TemplateRef
 } from '@angular/core';
@@ -13,14 +12,13 @@ import {
   templateUrl: './go-toast.component.html',
   styleUrls: ['./go-toast.component.scss']
 })
-export class GoToastComponent implements OnInit {
-  statusClass: string = 'go-toast-status--neutral';
-  icon: string = 'notifications_none';
+export class GoToastComponent {
   duration: number;
 
   @Input() dismissable: boolean = false;
   @Input() enableMaxHeight: boolean = true;
   @Input() header: string;
+  @Input() icon: string;
   @Input() message: string;
   @Input() showToastActions: boolean = false;
   @Input() theme: 'light' | 'dark' = 'light';
@@ -40,18 +38,22 @@ export class GoToastComponent implements OnInit {
    */
   @ContentChild('messageContent') messageContent: TemplateRef<any>;
 
-  ngOnInit(): void {
-    this.statusClass = this.getStatus();
-    this.icon = this.getIcon();
+  get _icon(): string {
+    if (this.icon) {
+      return this.icon;
+    } else {
+      switch (this.type) {
+        case 'positive':
+          return 'done';
+        case 'negative':
+          return 'priority_high';
+        default:
+          return 'notifications_none';
+      }
+    }
   }
 
-  public dismiss(): void {
-    this.handleDismiss.emit();
-  }
-
-  //#region Private Methods
-
-  private getStatus(): string {
+  get _status(): string {
     switch (this.type) {
       case 'positive':
         return 'go-toast-status--positive';
@@ -62,16 +64,7 @@ export class GoToastComponent implements OnInit {
     }
   }
 
-  private getIcon(): string {
-    switch (this.type) {
-      case 'positive':
-        return 'done';
-      case 'negative':
-        return 'priority_high';
-      default:
-        return 'notifications_none';
-    }
+  dismiss(): void {
+    this.handleDismiss.emit();
   }
-
-  //#endregion
 }

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
@@ -54,6 +54,16 @@
       </div>
 
       <div class="go-column go-column--100">
+        <h4 class="go-heading-4">icon</h4>
+        <p class="go-body-copy go-body-copy--no-margin">
+          Changes the icon that is displayed within the toast. This is set automatically for each type, but if a value
+          is passed for this binding it will override all of those type icons. See the
+          <a class="go-link" href="https://material.io/tools/icons/">Material Design System Icons</a>
+          page for available icons.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100">
         <h4 class="go-heading-4">message</h4>
         <p class="go-body-copy go-body-copy--no-margin">
           The text or non-executable HTML to be displayed as the message of the toast. This is optional, however either this binding or the
@@ -277,6 +287,30 @@
     header="Success!"
     message="The thing you did saved successfully." 
     type="positive">
+  </go-toast>
+
+  <go-card class="go-column go-column--100" id="toast-icon">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Icon Example</h2>
+      <go-copy cardId="toast-icon" goCopyCardLink></go-copy>
+    </ng-container>
+    <ng-container go-card-content>
+      <div class="go-column go-column--100">
+        <p class="go-body-copy go-body-copy--no-margin">
+          An icon may be specified with the <code class="code-block--inline">@Input icon: string;</code>
+          binding. If a value is passed to this binding, it will override all of the default icons for each type.
+        </p>
+      </div>
+      <h4 class="go-heading-4">component.html</h4>
+      <code [highlight]="toast_icon_template_html"></code>
+    </ng-container>
+  </go-card>
+
+  <go-toast
+    class="go-column go-column--100"
+    icon="pets"
+    header="Icon Chaos!"
+    message="This shows an example where the icon has been set to something unique from the Material Icons library.">
   </go-toast>
 
   <go-card class="go-column go-column--100" id="max-height">

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
@@ -39,6 +39,13 @@
       </div>
 
       <div class="go-column go-column--100">
+        <h4 class="go-heading-4">enableMaxHeight</h4>
+        <p class="go-body-copy go-body-copy--no-margin">
+          By default this is true, but if set to false will allow the toast to expand to the size of its content.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100">
         <h4 class="go-heading-4">header</h4>
         <p class="go-body-copy go-body-copy--no-margin">
           The text to be displayed as the header of the toast. This is optional, however either this binding or the
@@ -249,7 +256,7 @@
   <go-card class="go-column go-column--100" id="toast-theme">
     <ng-container go-card-header>
       <h2 class="go-heading-2 go-heading--no-wrap">Theme</h2>
-      <go-copy cardId="theme-template" goCopyCardLink></go-copy>
+      <go-copy cardId="toast-theme" goCopyCardLink></go-copy>
     </ng-container>
     <ng-container go-card-content>
       <div class="go-column go-column--100">
@@ -270,6 +277,52 @@
     header="Success!"
     message="The thing you did saved successfully." 
     type="positive">
-</go-toast>
+  </go-toast>
+
+  <go-card class="go-column go-column--100" id="max-height">
+    <ng-container go-card-header>
+      <h2 class="go-heading-2 go-heading--no-wrap">Max Height Example</h2>
+      <go-copy cardId="max-height" goCopyCardLink></go-copy>
+    </ng-container>
+    <div class="go-container" go-card-content>
+      <div class="go-column go-column--100">
+        By default, the toasts have a max height that allows for vertical overflow scrolling. See below:
+      </div>
+      <div class="go-column go-column--50">
+        <h4 class="go-heading-4 go-heading--underlined">View</h4>
+        <go-toast header="Something you should know...">
+          <ng-template #messageContent>
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+          </ng-template>
+        </go-toast>
+      </div>
+      <div class="go-column go-column--50">
+        <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+        <code
+          [highlight]="toast_maxHeight_html"
+          class="code-block--no-bottom-margin">
+        </code>
+      </div>
+
+      <div class="go-column go-column--100">
+        To disable the max height restriction on toasts, you can pass in a binding:
+      </div>
+      <div class="go-column go-column--50">
+        <h4 class="go-heading-4 go-heading--underlined">View</h4>
+        <go-toast header="Show me everything!" [enableMaxHeight]="false">
+          <ng-template #messageContent>
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+          </ng-template>
+        </go-toast>
+      </div>
+      <div class="go-column go-column--50">
+        <h4 class="go-heading-4 go-heading--underlined">Code</h4>
+        <code
+          [highlight]="toast_maxHeight_enable_html"
+          class="code-block--no-bottom-margin">
+        </code>
+      </div>
+    </div>
+  </go-card>
 
 </section>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
@@ -13,8 +13,11 @@ export class ToastDocsComponent {
 
   componentBindings: string = `
   @Input() dismissable: boolean = false;
+  @Input() enableMaxHeight: boolean = true;
   @Input() header: string;
   @Input() message: string;
+  @Input() showToastActions: boolean = false;
+  @Input() theme: 'light' | 'dark' = 'light';
   @Input() type: string;
 
   @Output() handleDismiss = new EventEmitter();
@@ -131,6 +134,21 @@ export class ToastDocsComponent {
     header="Success!"
     message="The thing you did saved successfully."
     type="positive">
+  </go-toast>
+  `;
+
+  toast_maxHeight_html: string = `
+  <go-toast
+    header="Something you should know..."
+    message="Sed ut perspiciatis... *redacted for brevity* ...voluptas nulla pariatur?">
+  </go-toast>
+  `;
+
+  toast_maxHeight_enable_html: string = `
+  <go-toast
+    [enableMaxHeight]="false"
+    header="Show me everything!"
+    message="Sed ut perspiciatis... *redacted for brevity* ...voluptas nulla pariatur?">
   </go-toast>
   `;
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
@@ -15,6 +15,7 @@ export class ToastDocsComponent {
   @Input() dismissable: boolean = false;
   @Input() enableMaxHeight: boolean = true;
   @Input() header: string;
+  @Input() icon: string;
   @Input() message: string;
   @Input() showToastActions: boolean = false;
   @Input() theme: 'light' | 'dark' = 'light';
@@ -149,6 +150,14 @@ export class ToastDocsComponent {
     [enableMaxHeight]="false"
     header="Show me everything!"
     message="Sed ut perspiciatis... *redacted for brevity* ...voluptas nulla pariatur?">
+  </go-toast>
+  `;
+
+  toast_icon_template_html: string = `
+  <go-toast
+    icon="pets"
+    header="Icon Chaos!"
+    message="This shows an example where the icon has been set to something unique from the Material Icons library.">
   </go-toast>
   `;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Toasts do not have a max height.
Toast icons are set programmatically based on `type` binding.

Resolves #815 

## What is the new behavior?
Toasts now have a max height, with a new binding to provide the ability to disable the max height.
Toasts now have an `icon` binding that, when passed, will override all of the programmatically set icons for a toast.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
