### PR TITLE
[Feature] go-table wrapContent

### DIFF
--- a/projects/go-lib/src/lib/components/go-table/go-table-column.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table-column.component.ts
@@ -11,6 +11,7 @@ export class GoTableColumnComponent extends GoTableChildColumnComponent {
   @Input() sortable?: boolean;
   @Input() title: string;
   @Input() width: number;
+  @Input() wrapContent: boolean = null;
 
   @ContentChild('goTableHead') goTableHead: TemplateRef<any>;
 

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.html
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.html
@@ -118,7 +118,10 @@
             <!-- Body - Columns -->
             <td *ngFor="let col of columns"
                 class="go-table__body-column"
-                [ngClass]="{ 'go-table__body-row--expanded': item.showDetails }"
+                [ngClass]="{
+                  'go-table__body-row--expanded': item.showDetails,
+                  'go-table__body-column--no-wrap': col.wrapContent === null ? !wrapContent : !col.wrapContent
+                }"
                 [ngStyle]="{ 'vertical-align': col.alignment, 'min-width': col.width + 'px' }"
                 [@tableRowBorderAnim]="item.showDetails ? 'open' : 'close'">
               <ng-container *ngIf="!col.goTableCell; else columnCellOutlet">

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.scss
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.scss
@@ -135,6 +135,10 @@ $go-table-body-row-expanded-border: rgba(240, 240, 240, 0);
       }
     }
 
+    &--no-wrap {
+      white-space: nowrap;
+    }
+
     &--selectable {
       padding: calc(#{$go-table-cell-vertical-padding} / 2) $go-table-cell-horizontal-padding;
       text-align: center;

--- a/projects/go-lib/src/lib/components/go-table/go-table.component.ts
+++ b/projects/go-lib/src/lib/components/go-table/go-table.component.ts
@@ -68,6 +68,7 @@ export class GoTableComponent implements OnInit, OnChanges, OnDestroy, AfterView
   @Input() stickyHeader: boolean = false;
   @Input() tableConfig: GoTableConfig;
   @Input() tableTitle: string;
+  @Input() wrapContent: boolean = true;
 
   /**
    * This event is emitted when a row's selection changes

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-column-docs/table-column-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-column-docs/table-column-docs.component.html
@@ -68,10 +68,18 @@
         </p>
       </div>
       
-      <div class="go-column go-column--100 go-column--no-padding">
+      <div class="go-column go-column--100">
         <h4 class="go-heading-4">width</h4>
         <p class="go-body-copy go-body-copy--no-margin">
           This binding sets the minimum possible width for column. The value must be in pixels.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <h4 class="go-heading-4">wrapContent</h4>
+        <p class="go-body-copy go-body-copy--no-margin">
+          This binding overrides the <code class="code-block--inline">wrapContent</code> binding on the <code class="code-block--inline">go-table</code>
+          component. By default it is unset and will not override the parent table's binding.
         </p>
       </div>
 
@@ -99,7 +107,7 @@
     <go-table-column field="email" width="50"></go-table-column>
     <go-table-column field="gender"></go-table-column>
     <go-table-column field="ip_address" title="IP Address"></go-table-column>
-    <go-table-column field="last_login" title="Last Login"></go-table-column>
+    <go-table-column field="last_login" title="Last Login" [wrapContent]="false"></go-table-column>
     <go-table-column field="alive"></go-table-column>
     <go-table-column field="login_attempts" title="Login Attempts"></go-table-column>
   </go-table>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-column-docs/table-column-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-column-docs/table-column-docs.component.ts
@@ -20,6 +20,7 @@ export class TableColumnDocsComponent {
   @Input() sortable?:  boolean = true;
   @Input() title:      string;
   @Input() width:      number;
+  @Input() wrapContent: boolean = null;
   `;
 
   fieldExample: string = `
@@ -45,6 +46,9 @@ export class TableColumnDocsComponent {
     <go-table-column field="email" width="50"></go-table-column>
     <go-table-column field="gender"></go-table-column>
     <go-table-column field="ip_address" title="IP Address"></go-table-column>
+    <go-table-column field="last_login" title="Last Login" [wrapContent]="false"></go-table-column>
+    <go-table-column field="alive"></go-table-column>
+    <go-table-column field="login_attempts" title="Login Attempts"></go-table-column>
   </go-table>
   `;
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-overview/table-overview.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-overview/table-overview.component.html
@@ -67,6 +67,13 @@
       </div>
 
       <div class="go-column go-column--100">
+        <h4 class="go-heading-4">stickyHeader</h4>
+        <p class="go-body-copy go-body-copy--no-margin">
+          This property enables sticky column headers on the table, this is optional and defaults to false.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100">
         <h4 class="go-heading-4">tableConfig</h4>
         <p class="go-body-copy">
           This is a class to represent the entire table data and its configurations.
@@ -82,6 +89,15 @@
         <h4 class="go-heading-4">tableTitle</h4>
         <p class="go-body-copy go-body-copy--no-margin">
           This property adds a title above the table, this is optional.
+        </p>
+      </div>
+
+      <div class="go-column go-column--100 go-column--no-padding">
+        <h4 class="go-heading-4">wrapContent</h4>
+        <p class="go-body-copy go-body-copy--no-margin">
+          This binding handles how the content of the table cells wrap. By default, content is wrapped. Note that the 
+          <code class="code-block--inline">go-table-column</code> component also has this binding and will override the parent table's
+          value for that individual column.
         </p>
       </div>
 

--- a/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-overview/table-overview.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/table-docs/components/table-overview/table-overview.component.ts
@@ -30,6 +30,7 @@ export class TableOverviewComponent {
   @Input() stickyHeader: boolean = false;
   @Input() tableConfig: GoTableConfig;
   @Input() tableTitle: string;
+  @Input() wrapContent: boolean = true;
   `;
 
   tableConfigClass: string = `


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
~~- [ ] Tests for the changes have been added~~
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Resolves #811 

## What is the new behavior?
Added a binding to the `go-table` component called `wrapContent` that controls whether the content in all of the table cells wraps or not.

Added a binding to the `go-table-column` component called `wrapContent` that controls the content wrapping for that individual column. Note: this binding will override the `wrapContent` binding on the `go-table` for that individual column.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
