### PR TITLE
[Bug] Issue #828 fix date validation

### DIFF
--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
@@ -138,8 +138,8 @@ describe('GoDatepickerComponent', () => {
       expect(component.control.value).toEqual(new Date(2015, 4, 16));
     });
 
-        it("should reset control ", () => {
-      component.control.setValue("09/16/2016");
+    it('should reset control', () => {
+      component.control.setValue('09/16/2016');
       component.control.reset();
 
       fixture.detectChanges();

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.ts
@@ -58,7 +58,10 @@ export class GoDatepickerComponent implements OnDestroy, OnInit {
       if (!value) {
         this.selectedDate = null;
       } else {
-        const dateValid: boolean = (value instanceof Date) && LocaleFormat.validDate(value.getMonth(), value.getDay(), value.getFullYear());
+        const localeDateIsValid: boolean = LocaleFormat.validDate(value.getMonth(), value.getDate(), value.getFullYear());
+
+        const dateValid: boolean = (value instanceof Date) && localeDateIsValid;
+
         if (!dateValid) {
           this.control.setErrors([{ message: 'format is invalid' }]);
         } else {

--- a/projects/go-lib/src/lib/components/go-datepicker/locale-format.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/locale-format.spec.ts
@@ -2,9 +2,6 @@ import {LocaleFormat} from './locale-format';
 
 describe('LocaleFormat', () => {
   describe('validDate()', () => {
-    /**
-     * @see https://github.com/mobi/goponents/issues/828
-     */
     it('should validate dates between jan & dec', () => {
       const jan: Date = new Date(2020, 0, 1);
       const dec: Date = new Date(2020, 11, 1);
@@ -20,14 +17,13 @@ describe('LocaleFormat', () => {
     /**
      * @see https://github.com/mobi/goponents/issues/828
      *
+     * it('should return false when dates are out of range', () => {
+     *   const badDate: Date = new Date(2021, -1, 32);
      *
-     *    it('should return false when dates are out of range', () => {
-     *      const badDate: Date = new Date(2021, -1, 32);
-     *
-     *      expect(LocaleFormat.validDate(badDate.getMonth(), badDate.getDate(), badDate.getFullYear())).toBeFalsy(
-     *        'Date(2020, -1, 32) should be invalid'
-     *      );
-     *    });
+     *   expect(LocaleFormat.validDate(badDate.getMonth(), badDate.getDate(), badDate.getFullYear())).toBeFalsy(
+     *     'Date(2020, -1, 32) should be invalid'
+     *   );
+     * });
      */
   });
 });

--- a/projects/go-lib/src/lib/components/go-datepicker/locale-format.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/locale-format.spec.ts
@@ -12,7 +12,9 @@ describe('LocaleFormat', () => {
       expect(LocaleFormat.validDate(jan.getMonth(), jan.getDate(), jan.getFullYear())).toBeTruthy(
         jan.toUTCString() + ' is not a valid date'
       );
-      expect(LocaleFormat.validDate(dec.getMonth(), dec.getDate(), dec.getFullYear())).toBeTruthy();
+      expect(LocaleFormat.validDate(dec.getMonth(), dec.getDate(), dec.getFullYear())).toBeTruthy(
+        dec.toUTCString() + ' is not a valid date'
+      );
     });
 
     /**

--- a/projects/go-lib/src/lib/components/go-datepicker/locale-format.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/locale-format.spec.ts
@@ -13,17 +13,5 @@ describe('LocaleFormat', () => {
         dec.toUTCString() + ' is not a valid date'
       );
     });
-
-    /**
-     * @see https://github.com/mobi/goponents/issues/828
-     *
-     * it('should return false when dates are out of range', () => {
-     *   const badDate: Date = new Date(2021, -1, 32);
-     *
-     *   expect(LocaleFormat.validDate(badDate.getMonth(), badDate.getDate(), badDate.getFullYear())).toBeFalsy(
-     *     'Date(2020, -1, 32) should be invalid'
-     *   );
-     * });
-     */
   });
 });

--- a/projects/go-lib/src/lib/components/go-datepicker/locale-format.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/locale-format.spec.ts
@@ -1,0 +1,31 @@
+import {LocaleFormat} from './locale-format';
+
+describe('LocaleFormat', () => {
+  describe('validDate()', () => {
+    /**
+     * @see https://github.com/mobi/goponents/issues/828
+     */
+    it('should validate dates between jan & dec', () => {
+      const jan: Date = new Date(2020, 0, 1);
+      const dec: Date = new Date(2020, 11, 1);
+
+      expect(LocaleFormat.validDate(jan.getMonth(), jan.getDate(), jan.getFullYear())).toBeTruthy(
+        jan.toUTCString() + ' is not a valid date'
+      );
+      expect(LocaleFormat.validDate(dec.getMonth(), dec.getDate(), dec.getFullYear())).toBeTruthy();
+    });
+
+    /**
+     * @see https://github.com/mobi/goponents/issues/828
+     *
+     *
+     *    it('should return false when dates are out of range', () => {
+     *      const badDate: Date = new Date(2021, -1, 32);
+     *
+     *      expect(LocaleFormat.validDate(badDate.getMonth(), badDate.getDate(), badDate.getFullYear())).toBeFalsy(
+     *        'Date(2020, -1, 32) should be invalid'
+     *      );
+     *    });
+     */
+  });
+});

--- a/projects/go-lib/src/lib/components/go-datepicker/locale-format.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/locale-format.ts
@@ -35,10 +35,10 @@ export class LocaleFormat {
 
   static validDate(month: number, day: number, year: number): boolean {
     const validDays: Array<number> = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-    if (year >= 10000 || month > 12 || month < 1) {
+    if (year >= 10000 || month > 11 || month < 0) {
       return false;
     }
-    if (day <= validDays[month - 1]) {
+    if (day <= validDays[month]) {
       return true;
     }
     if (year % 4 === 0 && month === 2 && day === 29) {
@@ -65,7 +65,7 @@ export class LocaleFormat {
       year = century + year;
     }
 
-    if (!this.validDate(month, day, year)) {
+    if (!this.validDate(month - 1, day, year)) {
       return null;
     }
 

--- a/projects/go-lib/src/lib/components/go-datepicker/locale-format.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/locale-format.ts
@@ -55,7 +55,12 @@ export class LocaleFormat {
 
   private static parseFromFormat(values: string[], locale: string): Date {
     const format: Array<string> = this.format(locale).split(/[/\-.]/);
-    const month: number = this.dateFromFormat(format, values, 'mm');
+
+    /**
+     * Month index: 0-11
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
+     */
+    const month: number = this.dateFromFormat(format, values, 'mm') - 1;
     const day: number = this.dateFromFormat(format, values, 'dd');
     let year: number = this.dateFromFormat(format, values, 'yyyy');
 
@@ -65,12 +70,12 @@ export class LocaleFormat {
       year = century + year;
     }
 
-    if (!this.validDate(month - 1, day, year)) {
+    if (!this.validDate(month, day, year)) {
       return null;
     }
 
     // Create a new date with the correct year month and date values based on the locale of the datepicker
-    return new Date(year, month - 1, day);
+    return new Date(year, month, day);
   }
 
   private static parseFromInternational(values: string[]): Date {

--- a/projects/go-tester/src/app/app-routing.module.ts
+++ b/projects/go-tester/src/app/app-routing.module.ts
@@ -12,9 +12,9 @@ const routes: Routes = [
   { path: '', component: LayoutComponent, children: [
     { path: 'test-page-1', component: TestPage1Component, canActivate: [AppGuard] },
     { path: 'test-page-2', component: TestPage2Component, canActivate: [AppGuard] },
-    { path: 'test-page-3', component: TestPage3Component, canActivate: [AppGuard] }
+    { path: 'test-page-3', component: TestPage3Component, canActivate: [AppGuard] },
+    { path: 'test-page-4', component: TestPage4Component }
   ]},
-  { path: 'test-page-4', component: TestPage4Component },
   { path: '**', redirectTo: '/test-page-1' }
 ];
 

--- a/projects/go-tester/src/app/components/layout/layout.component.ts
+++ b/projects/go-tester/src/app/components/layout/layout.component.ts
@@ -26,7 +26,8 @@ export class LayoutComponent implements OnInit {
       { route: '/test-page-1', routeTitle: 'Test 1', description: 'Test Route 1' },
       { route: '/test-page-2', routeTitle: 'Test 2' },
       { routeTitle: 'Test 3', description: 'Forms', subRoutes: [
-        { route: '/test-page-3', routeTitle: 'test 4' }
+        { route: '/test-page-3', routeTitle: 'test 3' },
+        { route: '/test-page-4', routeTitle: 'test 4' }
       ]}
     ]},
     { routeIcon: 'explore', routeTitle: 'Second Test', route: '/test-page-4', description: 'Test Route 4' },

--- a/projects/go-tester/src/app/components/test-page-4/test-page-4.component.html
+++ b/projects/go-tester/src/app/components/test-page-4/test-page-4.component.html
@@ -1,3 +1,19 @@
-<p>Page 4 works!</p>
+<div class="go-container">
+  <div class="go-column">
+    <h1>Test Page 4</h1>
+  </div>
+</div>
+
+<form class="go-container card-form-dark">
+  <div class="go-column go-column--50">
+    <go-datepicker
+      #datePicker
+      [control]="form.controls.date"
+    ></go-datepicker>
+  </div>
+  <div class="go-column go-column--50">
+    <go-button (click)="submitForm()">Submit</go-button>
+  </div>
+</form>
 
 <a [routerLink]="['/test-page-1', 123]">Redirect</a>

--- a/projects/go-tester/src/app/components/test-page-4/test-page-4.component.ts
+++ b/projects/go-tester/src/app/components/test-page-4/test-page-4.component.ts
@@ -1,11 +1,29 @@
-import { Component } from '@angular/core';
+import {AfterViewInit, Component, ContentChild, OnInit, ViewChild} from '@angular/core';
+import {FormBuilder, FormControl, FormGroup} from '@angular/forms';
+import {GoDatepickerComponent} from '../../../../../go-lib/src/lib/components/go-datepicker/go-datepicker.component';
 
 @Component({
   selector: 'app-test-page-4',
   templateUrl: './test-page-4.component.html'
 })
-export class TestPage4Component {
+export class TestPage4Component implements OnInit, AfterViewInit {
+  form: FormGroup;
 
-  constructor(
-  ) { }
+  @ViewChild('datePicker') dp: GoDatepickerComponent;
+
+  constructor() {
+    this.form = new FormGroup({
+      date: new FormControl('')
+    });
+  }
+
+  ngOnInit(): void {
+    console.log(this.dp);
+  }
+
+  ngAfterViewInit(): void {
+    this.dp.datePicked(new Date(2020, 0, 1));
+  }
+
+  submitForm(): void {}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When picking a date (GoDatepickerComponent) in January, the field shows as invalid format

Resolves #828

## What is the new behavior?
The dates are validated using 0-11 for the months as described in the [MDN docs for `getMonth()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth) 

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [ ] No
- [x] Maybe

The `LocaleFormat.validDate` function was changed.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
