### PR TITLE
FEATURE: Added unordered list styles

### DIFF
--- a/projects/go-lib/styles/_typography.scss
+++ b/projects/go-lib/styles/_typography.scss
@@ -112,7 +112,7 @@ strong {
   list-style-position: outside;
   list-style-type: disc;
 
-  &__inner {
+  &--inner {
     list-style-type: circle;
   }
 }

--- a/projects/go-lib/styles/_typography.scss
+++ b/projects/go-lib/styles/_typography.scss
@@ -11,6 +11,7 @@ strong {
 .go-heading {
   font-family: $primary-font-stack;
   font-weight: $weight-regular;
+  line-height: 1.4;
   margin-bottom: $heading-margin-bottom;
 }
 
@@ -100,5 +101,16 @@ strong {
   &__item {
     line-height: 1.5;
     margin: $column-gutter--half 0;
+  }
+}
+
+.go-unordered-list {
+  line-height: 1.6;
+  list-style-position: outside;
+  list-style-type: disc;
+  margin: 0 0 2rem 1.1rem;
+
+  &__inner {
+    list-style-type: circle;
   }
 }

--- a/projects/go-lib/styles/_typography.scss
+++ b/projects/go-lib/styles/_typography.scss
@@ -11,7 +11,7 @@ strong {
 .go-heading {
   font-family: $primary-font-stack;
   font-weight: $weight-regular;
-  line-height: 1.4;
+  line-height: 1.3;
   margin-bottom: $heading-margin-bottom;
 }
 
@@ -93,22 +93,24 @@ strong {
   }
 }
 
-.go-ordered-list {
-  list-style: decimal;
+.go-ordered-list,
+.go-unordered-list {
+  line-height: 1.5;
   margin: 0 $column-gutter $column-gutter--three-quarters;
   padding-left: 1rem;
+}
+
+.go-ordered-list {
+  list-style: decimal;
 
   &__item {
-    line-height: 1.5;
     margin: $column-gutter--half 0;
   }
 }
 
 .go-unordered-list {
-  line-height: 1.6;
   list-style-position: outside;
   list-style-type: disc;
-  margin: 0 0 2rem 1.1rem;
 
   &__inner {
     list-style-type: circle;

--- a/projects/go-lib/styles/_variables.scss
+++ b/projects/go-lib/styles/_variables.scss
@@ -56,7 +56,7 @@ $base-letter-spacing: .08pt;
 $secondary-weight-light: 300;
 $secondary-weight-medium: 600;
 
-$heading-margin-bottom: 1.5rem;
+$heading-margin-bottom: 1rem;
 $heading-sizes: (
   1: 1.875rem,
   2: 1.625rem,


### PR DESCRIPTION
Added a class for unordered lists. Also added line-height to go-headings for text-wrapping

## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [x] Other... Please describe: New class for unordered lists

## What is the current behavior?
There are no common styles for `<ul>` elements

Resolves #831 

## What is the new behavior?
All `<ul>` moving forward will be styled the same way (using the goponent classname)


## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
