### PR TITLE
Fix to show options button text in a single line.

### DIFF
--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -459,6 +459,7 @@ $button-shadow-secondary-active: 0 0 0 3px transparentize($theme-light-bg-hover,
     @include transition;
     @include z-index(off-canvas);
 
+	white-space: nowrap;
     background: $theme-light-bg;
     border: 1px solid $base-light-tertiary;
     border-radius: $global-radius;
@@ -482,7 +483,6 @@ $button-shadow-secondary-active: 0 0 0 3px transparentize($theme-light-bg-hover,
     cursor: pointer;
     font-size: .875rem;
     font-weight: normal;
-    max-width: 10rem;
     padding: .75rem;
 
     &:hover {

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -459,7 +459,6 @@ $button-shadow-secondary-active: 0 0 0 3px transparentize($theme-light-bg-hover,
     @include transition;
     @include z-index(off-canvas);
 
-	white-space: nowrap;
     background: $theme-light-bg;
     border: 1px solid $base-light-tertiary;
     border-radius: $global-radius;
@@ -469,6 +468,7 @@ $button-shadow-secondary-active: 0 0 0 3px transparentize($theme-light-bg-hover,
     right: 0;
     top: calc(2rem + 2px);
     visibility: hidden;
+    white-space: nowrap;
 
     &--active {
       opacity: 1;


### PR DESCRIPTION
Fix to show options button text in a single line.

## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Options text in splitbutton was wrapping if its length is bigger than the primary button. 

Resolves #848 

## What is the new behavior?
Options button text will not wrap and will extend from right to left. 

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
