### PR TITLE
Update go-button.component.scss

### DIFF
--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -468,6 +468,7 @@ $button-shadow-secondary-active: 0 0 0 3px transparentize($theme-light-bg-hover,
     right: 0;
     top: calc(2rem + 2px);
     visibility: hidden;
+    white-space: nowrap;
 
     &--active {
       opacity: 1;
@@ -482,7 +483,6 @@ $button-shadow-secondary-active: 0 0 0 3px transparentize($theme-light-bg-hover,
     cursor: pointer;
     font-size: .875rem;
     font-weight: normal;
-    max-width: 10rem;
     padding: .75rem;
 
     &:hover {


### PR DESCRIPTION
Changes for split button option text not to wrap and grow towards left.

## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Options text in splitbutton was wrapping if its length is bigger than the primary button.

Resolves #848

Options button text will not wrap and will extend from right to left.


## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
