### PR TITLE
Changes_GOP-877,GOP-876,GOP-847-BUG-minimum_height_for_textarea

### DIFF
--- a/projects/go-lib/src/lib/components/go-file-upload/go-file-upload.component.ts
+++ b/projects/go-lib/src/lib/components/go-file-upload/go-file-upload.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, FormArray, FormBuilder, FormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -20,6 +20,7 @@ export class GoFileUploadComponent extends GoFormBaseComponent implements OnInit
   @Input() isLoading: boolean = false;
   @Input() multiple: boolean = false;
   @Input() state: 'selecting' | 'selected' = 'selecting';
+  @ViewChild('filePicker') filePicker: any;
 
   ngOnInit(): void {
     this.fb = new FormBuilder();
@@ -51,6 +52,7 @@ export class GoFileUploadComponent extends GoFormBaseComponent implements OnInit
         this.filePreview.push(file.name);
       });
     }
+    this.filePicker.nativeElement.value = '';
   }
 
   removeFile(index: number): void {

--- a/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.html
+++ b/projects/go-lib/src/lib/components/go-text-area/go-text-area.component.html
@@ -9,7 +9,7 @@
     <go-required-text [control]="control"></go-required-text>
   </label>
   <textarea
-    class="go-form__input"
+    class="go-form__input go-form__textarea"
     [id]="_id"
     [ngClass]="inputClasses"
     [placeholder]="placeholder"

--- a/projects/go-lib/styles/_forms.scss
+++ b/projects/go-lib/styles/_forms.scss
@@ -1,7 +1,7 @@
-@import "./variables";
-@import "./mixins";
+@import './variables';
+@import './mixins';
 
-$input--disabled-background: rgba($base-dark-secondary, 0.4);
+$input--disabled-background: rgba($base-dark-secondary, .4);
 
 .go-form {
   // Fieldsets
@@ -50,11 +50,11 @@ $input--disabled-background: rgba($base-dark-secondary, 0.4);
     color: $theme-light-color;
     display: block;
     font-family: $primary-font-stack;
-    font-size: 0.75rem;
+    font-size: .75rem;
     font-weight: $weight-medium;
-    letter-spacing: 0.08pt;
+    letter-spacing: .08pt;
     line-height: 1.3;
-    padding-bottom: 0.375rem;
+    padding-bottom: .375rem;
 
     &--checkbox-container {
       cursor: pointer;
@@ -136,16 +136,16 @@ $input--disabled-background: rgba($base-dark-secondary, 0.4);
     border: 1px solid $base-light-tertiary;
     border-radius: $global-radius;
     display: inline-block;
-    height: 0.875rem;
+    height: .875rem;
     left: 0;
     position: absolute;
-    top: 0.1rem;
-    width: 0.875rem;
+    top: .1rem;
+    width: .875rem;
 
     &::after {
       border: solid $base-light;
       border-width: 0 1px 1px 0;
-      content: "";
+      content: '';
       display: none;
       height: 7px;
       left: 3.8px;
@@ -190,7 +190,7 @@ $input--disabled-background: rgba($base-dark-secondary, 0.4);
 
   &__checkbox:indeterminate ~ &__custom-checkbox::after {
     border: 1px solid $theme-light-border;
-    content: "";
+    content: '';
     display: block;
     height: 0;
     left: 3px;

--- a/projects/go-lib/styles/_forms.scss
+++ b/projects/go-lib/styles/_forms.scss
@@ -1,10 +1,9 @@
-@import './variables';
-@import './mixins';
+@import "./variables";
+@import "./mixins";
 
-$input--disabled-background: rgba($base-dark-secondary, .4);
+$input--disabled-background: rgba($base-dark-secondary, 0.4);
 
 .go-form {
-
   // Fieldsets
   // ---------------------------------------------
   &__fieldset {
@@ -51,11 +50,11 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
     color: $theme-light-color;
     display: block;
     font-family: $primary-font-stack;
-    font-size: .75rem;
+    font-size: 0.75rem;
     font-weight: $weight-medium;
-    letter-spacing: .08pt;
+    letter-spacing: 0.08pt;
     line-height: 1.3;
-    padding-bottom: .375rem;
+    padding-bottom: 0.375rem;
 
     &--checkbox-container {
       cursor: pointer;
@@ -96,6 +95,12 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
     }
   }
 
+  // TextArea
+  // ---------------------------------------------
+  &__textarea {
+    min-height: 70px;
+  }
+
   // Selects
   // ---------------------------------------------
   &__select {
@@ -131,16 +136,16 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
     border: 1px solid $base-light-tertiary;
     border-radius: $global-radius;
     display: inline-block;
-    height: .875rem;
+    height: 0.875rem;
     left: 0;
     position: absolute;
-    top: .1rem;
-    width: .875rem;
+    top: 0.1rem;
+    width: 0.875rem;
 
     &::after {
       border: solid $base-light;
       border-width: 0 1px 1px 0;
-      content: '';
+      content: "";
       display: none;
       height: 7px;
       left: 3.8px;
@@ -185,7 +190,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
 
   &__checkbox:indeterminate ~ &__custom-checkbox::after {
     border: 1px solid $theme-light-border;
-    content: '';
+    content: "";
     display: block;
     height: 0;
     left: 3px;

--- a/projects/go-lib/styles/_forms.scss
+++ b/projects/go-lib/styles/_forms.scss
@@ -5,7 +5,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
 
 .go-form {
   // Fieldsets
-  // ---------------------------------------------
+  // ----------------------------------------------
   &__fieldset {
     border: 1px solid $theme-light-border;
     border-radius: $global-radius;
@@ -45,7 +45,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   }
 
   // Labels
-  // ---------------------------------------------
+  // ----------------------------------------------
   &__label {
     color: $theme-light-color;
     display: block;
@@ -75,7 +75,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   }
 
   // Inputs
-  // ---------------------------------------------
+  // ----------------------------------------------
   &__input {
     @include transition(all);
     @include regular-input;
@@ -96,13 +96,13 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   }
 
   // TextArea
-  // ---------------------------------------------
+  // ----------------------------------------------
   &__textarea {
     min-height: 70px;
   }
 
   // Selects
-  // ---------------------------------------------
+  // ----------------------------------------------
   &__select {
     @include transition(all);
     @include regular-input;
@@ -112,7 +112,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   }
 
   // Checkboxes
-  // ---------------------------------------------
+  // ----------------------------------------------
   &__checkbox {
     margin-bottom: $column-gutter--three-quarters;
     margin-right: $column-gutter--three-quarters;
@@ -204,7 +204,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   }
 
   // Dark Overrides
-  // ---------------------------------------------
+  // ----------------------------------------------
   &--dark,
   &--dark &__input,
   &--dark &__select,
@@ -226,7 +226,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   }
 
   // Margin Overrides
-  // ---------------------------------------------
+  // ----------------------------------------------
   &__select--no-margin,
   &__input--no-margin,
   &__fieldset--no-margin {
@@ -234,7 +234,7 @@ $input--disabled-background: rgba($base-dark-secondary, .4);
   }
 
   // Error Overrides
-  // ---------------------------------------------
+  // ----------------------------------------------
   &__select--error,
   &__input--error {
     border-color: $ui-color-negative;

--- a/projects/go-lib/styles/_typography.scss
+++ b/projects/go-lib/styles/_typography.scss
@@ -30,6 +30,10 @@ strong {
   margin-bottom: $column-gutter--three-quarters;
 }
 
+go-body-copy:last-child {
+  margin-bottom: 0;
+}
+
 .go-heading--no-margin,
 .go-body-copy--no-margin {
   @extend %element--no-margin;


### PR DESCRIPTION
Fixed GOP-876 uniform card margins, GOP-877 set minimum_height_for_textarea and GOP-847 file uploading component bug fix.

## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?

Resolves <!-- Issue Number -->

#877 
#876 
#847 

## What is the new behavior?
#877 - Textarea will have the minimum width as 70px.
#876 - Last child of the card content will have no margin bottom.
#847 - Reselecting the same file after clearing is working fine.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
