### PR TITLE
884 accordion styling(normal&dark theme)

### DIFF
--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
@@ -90,7 +90,7 @@
       &.go-accordion-panel__header--dark {
         background-color: darken($base-dark-secondary, 3.5%);
       }
-      
+
       &.go-accordion-panel__header--dark:hover {
         background-color: darken($base-dark-secondary, 7%);
       }

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
@@ -76,13 +76,13 @@
     }
 
     &--dark {
-      background-color: #313536;
+      background-color: $base-dark;
 
       &:hover {
-        background-color: #313536;
+        background-color: darken($base-dark, 3.5%);
       }
     }
-
+    
     &--active {
       background-color: darken($base-light, 3.5%);
 
@@ -148,7 +148,7 @@
 
 // ----- Dark Theme Classes
 .go-accordion--theme-dark {
-  background: #313536;
+  background: $theme-dark-bg;
   border: 1px solid $theme-dark-border;
   color: $theme-dark-color;
   font-weight: $weight-light;

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
@@ -82,12 +82,15 @@
         background-color: darken($base-dark, 3.5%);
       }
     }
-    
+
     &--active {
       background-color: darken($base-light, 3.5%);
 
       // scss-lint:disable SelectorFormat
       &.go-accordion-panel__header--dark {
+        background-color: darken($base-dark-secondary, 3.5%);
+      }
+      &.go-accordion-panel__header--dark:hover {
         background-color: darken($base-dark-secondary, 7%);
       }
     }
@@ -132,12 +135,12 @@
   }
 
   &__content {
-    padding: 1.5rem 1rem;
     font-size: 0.875rem;
+    padding: 1rem 1rem;
 
     &--slim {
-      padding: 1rem;
       font-size: 0.875rem;
+      padding: 1rem;
     }
 
     &--no-padding {

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
@@ -90,6 +90,7 @@
       &.go-accordion-panel__header--dark {
         background-color: darken($base-dark-secondary, 3.5%);
       }
+      
       &.go-accordion-panel__header--dark:hover {
         background-color: darken($base-dark-secondary, 7%);
       }
@@ -136,7 +137,7 @@
 
   &__content {
     font-size: 0.875rem;
-    padding: 1rem 1rem;
+    padding: 1rem;
 
     &--slim {
       font-size: 0.875rem;

--- a/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
+++ b/projects/go-lib/src/lib/components/go-accordion/go-accordion-panel.component.scss
@@ -67,7 +67,7 @@
 
     cursor: pointer;
     display: flex;
-    font-size: 1.2rem;
+    font-size: 1.125rem;
     padding: 1.2rem 1rem;
     position: relative;
 
@@ -76,10 +76,10 @@
     }
 
     &--dark {
-      background-color: darken($base-dark-secondary, 7%);
+      background-color: #313536;
 
       &:hover {
-        background-color: darken($base-dark-secondary, 3.5%);
+        background-color: #313536;
       }
     }
 
@@ -93,8 +93,8 @@
     }
 
     &--slim {
-      font-size: 1rem;
-      padding: 1rem;
+      font-size: 0.875rem;
+      padding: 0.625rem 1rem;
     }
   }
 
@@ -133,9 +133,11 @@
 
   &__content {
     padding: 1.5rem 1rem;
+    font-size: 0.875rem;
 
     &--slim {
       padding: 1rem;
+      font-size: 0.875rem;
     }
 
     &--no-padding {
@@ -146,7 +148,7 @@
 
 // ----- Dark Theme Classes
 .go-accordion--theme-dark {
-  background: $theme-dark-bg;
+  background: #313536;
   border: 1px solid $theme-dark-border;
   color: $theme-dark-color;
   font-weight: $weight-light;

--- a/projects/go-lib/src/lib/components/go-button/go-button.component.scss
+++ b/projects/go-lib/src/lib/components/go-button/go-button.component.scss
@@ -54,7 +54,7 @@ $button-shadow-secondary-active: 0 0 0 3px transparentize($theme-light-bg-hover,
   }
 
   &--icon-only {
-    padding: calc(.625rem - 2px) .625rem;
+    padding: calc(.625rem - 2px) 1rem;
   }
 
   &__icon ~ &__text:not(:empty) {


### PR DESCRIPTION
[Chore] Accordion Styling (Normal & Dark theme) #884


## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:



Resolves 884

## What is the new behavior?
Changed below styles
Default Accordion

Header should be equivalent to an H4 (18px - 1.125rem).
The body contains unexpected padding around the content (1.5rem top/bottom) where UX outlined in as 1rem all around.
The body text should always be 14px (0.875rem) default.

Slim Accordion

Header should be equivalent to an H5 (14px - 0.875rem).
Header section padding should be 10px (0.625rem) top and bottom and 16px(1rem) left and right
The body text should always be 14px (0.875rem) default.
The padding around the body should be 16px (1rem) all around.

Dark Theme

Follows the above rules with the following additions
Header background color when collapsed is #313536
Header background color hovered when collapsed is #313536 3.5% darkened (HEX equivalent #292C2D)
Header background color when expanded is #181C1C.
Header background color hovered when expanded is #181C1C 3.5% darkened (HEX equivalent #101212)
border-radius needs to be 0px when the accordion reached the full width of the off-canvas container.


## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
