### PR TITLE
Changes [CHORE] 868 max height for toast

### DIFF
--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -9,7 +9,7 @@
   </div>
   <div
     class="go-toast__container"
-    [ngClass]=" enableMaxHeight?'go-toast__container--max-height':'go-toast__container' ">
+    [ngClass]="enableMaxHeight?'go-toast__container--max-height':'go-toast__container'">
     <div
       class="go-toast-content"
       [ngClass]="{ 'go-toast-content--no-title': !header }">

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -9,7 +9,7 @@
   </div>
   <div
     class="go-toast__container"
-    [ngClass]="enableMaxHeight?'go-toast__container--max-height':'go-toast__container'">
+    [ngClass]="enableMaxHeight ? 'go-toast__container--max-height' : 'go-toast__container'">
     <div
       class="go-toast-content"
       [ngClass]="{ 'go-toast-content--no-title': !header }">

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.html
@@ -9,7 +9,7 @@
   </div>
   <div
     class="go-toast__container"
-    [ngClass]="{ 'go-toast__container--max-height': enableMaxHeight }">
+    [ngClass]=" enableMaxHeight?'go-toast__container--max-height':'go-toast__container' ">
     <div
       class="go-toast-content"
       [ngClass]="{ 'go-toast-content--no-title': !header }">

--- a/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
+++ b/projects/go-lib/src/lib/components/go-toast/go-toast.component.ts
@@ -16,7 +16,7 @@ export class GoToastComponent {
   duration: number;
 
   @Input() dismissable: boolean = false;
-  @Input() enableMaxHeight: boolean = true;
+  @Input() enableMaxHeight: boolean = false;
   @Input() header: string;
   @Input() icon: string;
   @Input() message: string;

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.html
@@ -41,7 +41,7 @@
       <div class="go-column go-column--100">
         <h4 class="go-heading-4">enableMaxHeight</h4>
         <p class="go-body-copy go-body-copy--no-margin">
-          By default this is true, but if set to false will allow the toast to expand to the size of its content.
+          By default this is false, but if set to true will allow the toast to have a max height that allows for vertical overflow scrolling.
         </p>
       </div>
 
@@ -320,11 +320,11 @@
     </ng-container>
     <div class="go-container" go-card-content>
       <div class="go-column go-column--100">
-        By default, the toasts have a max height that allows for vertical overflow scrolling. See below:
+        By default, the toasts allows to expand to the size of its content. See below:
       </div>
       <div class="go-column go-column--50">
         <h4 class="go-heading-4 go-heading--underlined">View</h4>
-        <go-toast header="Something you should know...">
+        <go-toast header="Show me everything!">
           <ng-template #messageContent>
             Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
           </ng-template>
@@ -339,11 +339,11 @@
       </div>
 
       <div class="go-column go-column--100">
-        To disable the max height restriction on toasts, you can pass in a binding:
+        To enable the max height on toasts, you can pass in a binding:
       </div>
       <div class="go-column go-column--50">
         <h4 class="go-heading-4 go-heading--underlined">View</h4>
-        <go-toast header="Show me everything!" [enableMaxHeight]="false">
+        <go-toast header="Something you should know..." [enableMaxHeight]="true">
           <ng-template #messageContent>
             Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
           </ng-template>

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
@@ -140,7 +140,7 @@ export class ToastDocsComponent {
 
   toast_maxHeight_html: string = `
   <go-toast
-    header="Something you should know..."
+    header="Show me everything!"
     message="Sed ut perspiciatis... *redacted for brevity* ...voluptas nulla pariatur?">
   </go-toast>
   `;
@@ -148,7 +148,7 @@ export class ToastDocsComponent {
   toast_maxHeight_enable_html: string = `
   <go-toast
     [enableMaxHeight]="true"
-    header="Show me everything!"
+    header="Something you should know..."
     message="Sed ut perspiciatis... *redacted for brevity* ...voluptas nulla pariatur?">
   </go-toast>
   `;

--- a/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
+++ b/projects/go-style-guide/src/app/features/ui-kit/components/toast-docs/toast-docs.component.ts
@@ -13,7 +13,7 @@ export class ToastDocsComponent {
 
   componentBindings: string = `
   @Input() dismissable: boolean = false;
-  @Input() enableMaxHeight: boolean = true;
+  @Input() enableMaxHeight: boolean = false;
   @Input() header: string;
   @Input() icon: string;
   @Input() message: string;
@@ -147,7 +147,7 @@ export class ToastDocsComponent {
 
   toast_maxHeight_enable_html: string = `
   <go-toast
-    [enableMaxHeight]="false"
+    [enableMaxHeight]="true"
     header="Show me everything!"
     message="Sed ut perspiciatis... *redacted for brevity* ...voluptas nulla pariatur?">
   </go-toast>


### PR DESCRIPTION
Max height for the toast notification will not have an overflow unless specified.

## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves #868

## What is the new behavior?
1. Toast notification will have the style as fit content by default.
2. To enable the scrollability behaviour `enableMaxHeight` should be set to `true`

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
