### PR TITLE
Fix for duplicate modal and offcanvas content

### DIFF
--- a/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
+++ b/projects/go-lib/src/lib/components/go-modal/go-modal.component.ts
@@ -65,7 +65,7 @@ export class GoModalComponent extends GoModalOptions implements OnInit, OnDestro
   loadComponent(): void {
     const componentFactory: ComponentFactory<{}> = this.componentFactoryResolver.resolveComponentFactory(this.currentComponent.component);
     const viewContainerRef: ViewContainerRef = this.goModalHost.viewContainerRef;
-
+    viewContainerRef.clear();
     const componentRef: ComponentRef<{}> = viewContainerRef.createComponent(componentFactory);
 
     Object.keys(this.currentComponent.bindings).forEach((key: string) => {

--- a/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.component.ts
+++ b/projects/go-lib/src/lib/components/go-off-canvas/go-off-canvas.component.ts
@@ -93,6 +93,7 @@ export class GoOffCanvasComponent extends GoOffCanvasOptions implements OnInit, 
       this.currentOffCanvasItem.component
     );
     const viewContainerRef: ViewContainerRef = this.goOffCanvasHost.viewContainerRef;
+    viewContainerRef.clear(); 
     const componentRef: ComponentRef<any> = viewContainerRef.createComponent(componentFactory);
 
     Object.keys(this.currentOffCanvasItem.bindings).forEach((key: string) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
go-modal and go-off-canvas keeps adding duplicates body contents when user hits enter key

<img width="229" alt="image" src="https://user-images.githubusercontent.com/105297923/196731664-1f97768d-e499-4da2-a16b-cccdc9e5b244.png">

Resolves [894](https://github.com/mobi/goponents/issues/894)

## What is the new behavior?
Should not create duplicate contents

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
