### PR TITLE
[Feature] #918 enhancement of go-date-picker

### DIFF
--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.html
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.html
@@ -17,7 +17,7 @@
     [(ngModel)]="selectedDate"
     (blur)="validateDate()"
     [disabled]="control.disabled"
-    (input)="closeCalendar()"
+    (input)="onInputCloseCalendar()"
     (click)="toggleDatepicker($event)"
   />
   <go-icon-button

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.html
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.html
@@ -17,6 +17,8 @@
     [(ngModel)]="selectedDate"
     (blur)="validateDate()"
     [disabled]="control.disabled"
+    (input)="closeCalendar()"
+    (click)="toggleDatepicker($event)"
   />
   <go-icon-button
     class="go-datepicker__toggle"

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
@@ -235,4 +235,15 @@ describe('GoDatepickerComponent', () => {
       expect(component.goCalendar.isOpen).toBe(false);
     });
   });
+
+  describe("onInputCloseCalendar", () => {
+    it('close the calendar when the user interacts with the date field by typing inside it. ', () => {
+      component.goCalendar.openCalendar(new Date());
+
+      component.onInputCloseCalendar();
+
+      expect(component.goCalendar.isOpen).toBe(false);
+    });
+  });
+
 });

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.spec.ts
@@ -14,6 +14,7 @@ import { GoFormErrorsModule } from '../go-form-errors/go-form-errors.module';
 describe('GoDatepickerComponent', () => {
   let component: GoDatepickerComponent;
   let fixture: ComponentFixture<GoDatepickerComponent>;
+  let inputElement: HTMLInputElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -41,6 +42,7 @@ describe('GoDatepickerComponent', () => {
     fixture = TestBed.createComponent(GoDatepickerComponent);
     component = fixture.componentInstance;
     component.control = new FormControl('');
+    inputElement = fixture.nativeElement.querySelector("input");
   });
 
   it('should create', () => {
@@ -243,6 +245,24 @@ describe('GoDatepickerComponent', () => {
       component.onInputCloseCalendar();
 
       expect(component.goCalendar.isOpen).toBe(false);
+    });
+  });
+
+  describe("onInputCloseCalendar", () => {
+    it("close the calendar when the user interacts with the date field by typing inside it. ", () => {
+      component.goCalendar.openCalendar(new Date());
+
+      component.onInputCloseCalendar();
+
+      expect(component.goCalendar.isOpen).toBe(false);
+    });
+
+    it("should call onInputCloseCalendar() when input event is emitted.", () => {
+      const onInputCloseCalendarSpy = spyOn(component, "onInputCloseCalendar");
+
+      inputElement.dispatchEvent(new Event("input"));
+
+      expect(onInputCloseCalendarSpy).toHaveBeenCalled();
     });
   });
 

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.ts
@@ -118,7 +118,8 @@ export class GoDatepickerComponent extends GoFormBaseComponent implements OnDest
   private initializePlaceholder(): void {
     this.placeholder = this.placeholder || LocaleFormat.format(this.locale);
   }
-  closeCalendar() {
+
+  public onInputCloseCalendar(): void {
     if (this.goCalendar.isOpen) {
       this.goCalendar.closeCalendar();
     }

--- a/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.ts
+++ b/projects/go-lib/src/lib/components/go-datepicker/go-datepicker.component.ts
@@ -118,4 +118,9 @@ export class GoDatepickerComponent extends GoFormBaseComponent implements OnDest
   private initializePlaceholder(): void {
     this.placeholder = this.placeholder || LocaleFormat.format(this.locale);
   }
+  closeCalendar() {
+    if (this.goCalendar.isOpen) {
+      this.goCalendar.closeCalendar();
+    }
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
<!-- Please check all that apply using "x". -->
- [x] The commit message follows our [guidelines](https://github.com/mobi/goponents/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Style Update (CSS)
- [ ] Other... Please describe:

## What is the current behavior?
Currently we are opening calendar only on click of calendar icon inside the date field of go-date-picker.

Resolves Enhance_go-date-picker_by_enabling_calendar_to_open_when_date_field_is_clicked_anywhere_within_it

## What is the new behavior?
New behavior - where the calendar opens upon clicking anywhere within the date field of go-date-picker, rather than being restricted to only clicking on the calendar icon. This enhancement will significantly enhance the user experience, providing a more intuitive and seamless process for selecting dates.

## Does this PR introduce a breaking change?
<!-- Please check either yes or no using "x". -->
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
