### PR TITLE
chore(release): bump version to v26.2.1

### DIFF
--- a/projects/go-lib/package.json
+++ b/projects/go-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goponents",
-  "version": "1.18.3",
+  "version": "26.2.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mobi/goponents.git"


### PR DESCRIPTION

## 📦 Release Summary
This PR bumps the version to **v26.2.1** as part of the planned release schedule.

## 🔧 Changes
- Updated version in `projects/go-lib/package.json`

## ✅ Validation
- Version increment follows semver
- Version is unique compared to `main` (required for npm publish)
