### PR TITLE
chore(release): bump version to v14.0.0

### DIFF
--- a/projects/go-lib/package.json
+++ b/projects/go-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goponents",
-  "version": "1.18.3",
+  "version": "14.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mobi/goponents.git"


### PR DESCRIPTION

## 📦 Release Summary
This PR bumps the version to **v14.0.0** as part of the planned release schedule.

## 🔧 Changes
- Updated version in `projects/go-lib/package.json`

## ✅ Validation
- Version increment follows semver
- Version is unique compared to `main` (required for npm publish)

## 🚀 Next Steps
- Merge this PR into `dev`
- Follow-up PR will merge `dev` → `main` to trigger release pipeline
