### PR TITLE
Fix Dev and Prod startup failures caused by leftover Angular v17 standalone component changes

### DIFF
--- a/projects/go-style-guide/src/app/app.module.ts
+++ b/projects/go-style-guide/src/app/app.module.ts
@@ -46,13 +46,7 @@ import { HighlightModule, HIGHLIGHT_OPTIONS } from 'ngx-highlightjs';
     {
       provide: HIGHLIGHT_OPTIONS,
       useValue: {
-        coreLibraryLoader: () => import('highlight.js/lib/core'),
-        languages: {
-          bash: () => import('highlight.js/lib/languages/bash'),
-          scss: () => import('highlight.js/lib/languages/scss'),
-          typescript: () => import('highlight.js/lib/languages/typescript'),
-          xml: () => import('highlight.js/lib/languages/xml'),
-        }
+        fullLibraryLoader: () => import('highlight.js')
       }
     }
   ],

--- a/projects/go-style-guide/src/app/features/standards/components/colors/colors.component.ts
+++ b/projects/go-style-guide/src/app/features/standards/components/colors/colors.component.ts
@@ -1,13 +1,8 @@
 import { Component } from '@angular/core';
-import { HighlightModule } from 'ngx-highlightjs';
-
-import { GoSharedModule } from 'projects/go-lib/src/public_api';
 
 @Component({
  templateUrl: './colors.component.html',
- styleUrls: ['./colors.component.scss'],
- standalone: true,
- imports: [GoSharedModule, HighlightModule]
+ styleUrls: ['./colors.component.scss']
 })
 export class ColorsComponent {
  pageTitle: string = 'Colors';

--- a/projects/go-style-guide/src/app/features/standards/standards.module.ts
+++ b/projects/go-style-guide/src/app/features/standards/standards.module.ts
@@ -21,10 +21,10 @@ import { SharedModule } from '../../shared/shared.module';
     GoSharedModule,
     FormsModule,
     ReactiveFormsModule,
-    SharedModule,
-    ColorsComponent
+    SharedModule
   ],
   declarations: [
+    ColorsComponent,
     GridComponent,
     StandardsComponent,
     TypographyComponent


### PR DESCRIPTION
During the Angular v17 upgrade, an attempt was made to adopt the Standalone Component architecture. Although most of the related changes were later reverted, some standalone component configurations and implementation artifacts remained in the codebase.